### PR TITLE
Add Postgres12 support

### DIFF
--- a/circleci/images/extbuilder/files/bin/build-ext
+++ b/circleci/images/extbuilder/files/bin/build-ext
@@ -5,7 +5,7 @@ set -euxo pipefail
 IFS=$'\n\t'
 
 # supported PostgreSQL releases
-pg_majors=( 10 11 )
+pg_majors=( 10 11 12 )
 
 # get codename from release file
 . /etc/os-release

--- a/circleci/images/extbuilder/files/sbin/install-extdeps
+++ b/circleci/images/extbuilder/files/sbin/install-extdeps
@@ -11,7 +11,9 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 # supported PostgreSQL releases
-pg_majors=( 10 11 )
+pg_majors=( 10 11 12 )
+
+pg_latest=12 
 
 # get codename from release file
 . /etc/os-release
@@ -30,8 +32,9 @@ APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
 
 # add pgdg repo to sources
 echo "Writing /etc/apt/sources.list.d/pgdg.list..." >&2
-echo "deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main" > \
-     /etc/apt/sources.list.d/pgdg.list
+echo "deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main ${pg_latest}" > \
+    /etc/apt/sources.list.d/postgresql.list
+
 
 # build list of needed server dev packages
 echo "Installing server-dev packages..." >&2

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -1,12 +1,15 @@
-ARG PG_MAJOR
+FROM buildpack-deps@sha256:19a482aad09128bd0c448373d933aa0f108dc8eb9be2317dca3797c646ce4b57
 
-FROM postgres:$PG_MAJOR
+ARG PG_MAJOR
+ENV PG_MAJOR $PG_MAJOR
 
 COPY files /tmp
 
-RUN set -ex; \
+RUN set -ex; \	
 	ln -s /tmp/sbin/* /usr/local/sbin/; \
 	ln -s /tmp/bin/* /usr/local/bin; \
 	install-testdeps
+
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
 
 WORKDIR /home/circleci

--- a/circleci/images/exttester/files/sbin/install-testdeps
+++ b/circleci/images/exttester/files/sbin/install-testdeps
@@ -10,6 +10,13 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
+# get codename from release file
+. /etc/os-release
+codename=${VERSION#*(}
+codename=${codename%)*}
+
+pg_latest=12
+
 # explicitly set user/group IDs
 groupadd -r circleci --gid=1729
 useradd -mg circleci --uid=1729 --shell=/bin/bash circleci
@@ -21,11 +28,41 @@ apt-get install -y --no-install-recommends \
   ca-certificates \
   curl \
   debian-archive-keyring \
-  gcc
+  gcc \
+  gnupg
+
+# import key and keep apt-key from issuing warnings
+echo "Importing PGDG key..." >&2
+curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | \
+APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
+
+
+# add pgdg repo to sources
+echo "Writing /etc/apt/sources.list.d/pgdg.list..." >&2
+echo "deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main ${pg_latest}" > \
+    /etc/apt/sources.list.d/postgresql.list
+
+
+pkg_cloud_url="https://packagecloud.io/install/repositories/citus-bot/the-process/script.deb.sh"
+
+curl -sf "${pkg_cloud_url}" | unique_id=exttester bash
+
+cat > /etc/apt/preferences.d/citusdata_the-process.pref <<EOF
+Package: postgresql-server-dev-*
+Pin: release o=packagecloud.io/citus-bot/the-process
+Pin-Priority: 700
+EOF
+
 
 echo "Installing tools for testing PostgreSQL extensions..." >&2
-apt-get update && apt-get install -y --no-install-recommends make libedit-dev \
- libpam0g-dev libselinux1-dev postgresql-common perl libcurl3 "postgresql-server-dev-${PG_MAJOR}"
+apt-get update && apt-get install -y --no-install-recommends make postgresql-common perl libcurl3 "postgresql-${PG_MAJOR}" "postgresql-server-dev-${PG_MAJOR}"
+
+# Give permission for usr so that circleci can write citus artifacts
+chmod o+w -R /usr/
+
+# install gosu so that we can run tests from root with circleci user
+apt-get install -y gosu
+
 
 # keep that image size small!
 echo "Cleaning up..." >&2

--- a/circleci/images/exttester/files/sbin/install-testdeps
+++ b/circleci/images/exttester/files/sbin/install-testdeps
@@ -23,18 +23,9 @@ apt-get install -y --no-install-recommends \
   debian-archive-keyring \
   gcc
 
-pkg_cloud_url="https://packagecloud.io/install/repositories/citusdata/the-process/script.deb.sh"
-
-curl -sf "${pkg_cloud_url}" | unique_id=exttester bash
-
-cat > /etc/apt/preferences.d/citusdata_the-process.pref <<EOF
-Package: postgresql-server-dev-*
-Pin: release o=packagecloud.io/citusdata/the-process
-Pin-Priority: 700
-EOF
-
 echo "Installing tools for testing PostgreSQL extensions..." >&2
-apt-get update && apt-get install -y --no-install-recommends make postgresql-common perl libcurl3 "postgresql-server-dev-${PG_MAJOR}"
+apt-get update && apt-get install -y --no-install-recommends make libedit-dev \
+ libpam0g-dev libselinux1-dev postgresql-common perl libcurl3 "postgresql-server-dev-${PG_MAJOR}"
 
 # keep that image size small!
 echo "Cleaning up..." >&2


### PR DESCRIPTION
This PR adds postgres12 support for our test images. 

Normally we were using pg base image, however this causes some problems with pg12. pg12 base image has libcurl4 not libcurl3 apt source. Therefore when we install libcurl it installs libcurl4 not libcurl3. This gives an error in citus compilation. I have used the same base image that is used in https://github.com/citusdata/the-process/blob/master/circleci/images/extbuilder/Dockerfile#L2. This base image has libcurl3 not libcurl4.

`citusdata` repository is updated with `citus-bot`.



