### PR TITLE
Add bash to stylechecker Dockerfile

### DIFF
--- a/circleci/images/stylechecker/Dockerfile
+++ b/circleci/images/stylechecker/Dockerfile
@@ -4,6 +4,7 @@ ARG TOOLS_VERSION=0.7.9
 RUN apk add --no-cache --virtual installdeps curl make sed && \
     apk add --no-cache \
         ca-certificates \
+        bash \
         git \
         gzip \
         openssh \


### PR DESCRIPTION
Right now our ci/*.sh scripts need to use `sh` instead of `bash`. This is
annoying, since some useful things are not supported (non exhaustive list):
1. `set -o pipefail`
2. Some variable string replacement syntax things