### PR TITLE
Install downgrade scripts, if possible

### DIFF
--- a/circleci/images/extbuilder/files/bin/build-ext
+++ b/circleci/images/extbuilder/files/bin/build-ext
@@ -33,7 +33,7 @@ build_ext() {
   CFLAGS=-Werror "${basedir}/configure" PG_CONFIG="/usr/lib/postgresql/${pg_major}/bin/pg_config" --enable-coverage
 
   installdir="${builddir}/install"
-  make -j$(nproc) && mkdir -p "${installdir}" && make DESTDIR="${installdir}" install
+  make -j$(nproc) && mkdir -p "${installdir}" && { make DESTDIR="${installdir}" install-all || make DESTDIR="${installdir}" install ; }
 
   cd "${installdir}" && find . -type f -print > "${builddir}/files.lst"
   tar cvf "${basedir}/install-${pg_major}.tar" `cat ${builddir}/files.lst`


### PR DESCRIPTION
We decided not to install downgrade scripts by default. That's why we need to replace `make install` steps with `make install-all` to be able to test the downgrade scripts on CI.

See: https://github.com/citusdata/citus/pull/4004