### PR TITLE
Update test images

### DIFF
--- a/circleci/images/citusupgradetester/files/sbin/install-extdeps
+++ b/circleci/images/citusupgradetester/files/sbin/install-extdeps
@@ -52,6 +52,12 @@ echo "deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main" > \
 echo "Installing server-dev packages..." >&2
 apt-get update && apt-get install -y --no-install-recommends postgresql-server-dev-$PG_MAJOR
 
+# we need autoconf and build-essential for running the tests
+# we need other libraries for configure to pass, even though we could use
+# --without-libcurl while configuring, we prefer this for now.
+apt-get install -y autoconf build-essential libcurl4-openssl-dev libicu-dev \
+ libreadline-dev libselinux1-dev libxslt-dev libssl-dev 
+
 # build list of postgres
 echo "Installing postgres packages..." >&2
 apt-get install -y --no-install-recommends postgresql-$PG_MAJOR

--- a/circleci/images/exttester/files/sbin/install-testdeps
+++ b/circleci/images/exttester/files/sbin/install-testdeps
@@ -58,6 +58,12 @@ EOF
 echo "Installing tools for testing PostgreSQL extensions..." >&2
 apt-get update && apt-get install -y --no-install-recommends make postgresql-common perl libcurl3 "postgresql-${PG_MAJOR}" "postgresql-server-dev-${PG_MAJOR}"
 
+# we need autoconf and build-essential for running the tests
+# we need other libraries for configure to pass, even though we could use
+# --without-libcurl while configuring, we prefer this for now.
+apt-get install -y autoconf build-essential libcurl4-openssl-dev \
+  libicu-dev libreadline-dev libselinux1-dev libxslt-dev libssl-dev 
+
 # Give permission for usr so that circleci can write citus artifacts
 chmod o+w -R /usr/
 

--- a/circleci/images/failtester/files/sbin/install-testdeps
+++ b/circleci/images/failtester/files/sbin/install-testdeps
@@ -53,6 +53,13 @@ EOF
 echo "Installing tools for testing PostgreSQL extensions..." >&2
 apt-get update && apt-get install -y --no-install-recommends make postgresql-common \
  perl libcurl3 "postgresql-${PG_MAJOR}" "postgresql-server-dev-${PG_MAJOR}"
+ 
+# we need autoconf and build-essential for running the tests
+# we need other libraries for configure to pass, even though we could use
+# --without-libcurl while configuring, we prefer this for now. 
+apt-get install -y autoconf build-essential libcurl4-openssl-dev \
+ libicu-dev libreadline-dev libselinux1-dev libxslt-dev libssl-dev 
+
 
 echo "Installing tools for failure testing..." >&2
 pip3 install -Ir /tmp/etc/requirements.txt

--- a/circleci/images/pgupgradetester/files/sbin/install-testdeps
+++ b/circleci/images/pgupgradetester/files/sbin/install-testdeps
@@ -53,6 +53,12 @@ sd_pkgs=( "${pg_majors[@]/#/postgresql-server-dev-}" )
 pg_pkgs=( "${pg_majors[@]/#/postgresql-}" )
 apt-get update && apt-get install -y --no-install-recommends make postgresql-common perl libcurl3 "${sd_pkgs[@]}" "${pg_pkgs[@]}"
 
+# we need autoconf and build-essential for running the tests
+# we need other libraries for configure to pass, even though we could use
+# --without-libcurl while configuring, we prefer this for now.
+apt-get install -y autoconf build-essential libcurl4-openssl-dev \
+ libicu-dev libreadline-dev libselinux1-dev libxslt-dev libssl-dev 
+
 echo "Installing tools for failure testing..." >&2
 pip install -Ir /tmp/etc/requirements.txt
 


### PR DESCRIPTION
As we are separating the builds for each pg major, we needed to add some
additional packages to some of the images to be able to pass configure
and run tests.