### PR TITLE
Add locales to test containers

### DIFF
--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -2,10 +2,11 @@ FROM buildpack-deps@sha256:19a482aad09128bd0c448373d933aa0f108dc8eb9be2317dca379
 
 ARG PG_MAJOR
 ENV PG_MAJOR $PG_MAJOR
+ENV PATH=/usr/lib/postgresql/$PG_MAJOR/bin/:$PATH
 
 COPY files /tmp
 
-RUN set -ex; \	
+RUN set -ex; \
 	ln -s /tmp/sbin/* /usr/local/sbin/; \
 	ln -s /tmp/bin/* /usr/local/bin; \
 	install-testdeps

--- a/circleci/images/exttester/files/sbin/install-testdeps
+++ b/circleci/images/exttester/files/sbin/install-testdeps
@@ -21,6 +21,9 @@ pg_latest=13
 groupadd -r circleci --gid=1729
 useradd -mg circleci --uid=1729 --shell=/bin/bash circleci
 
+# make sure that when running container interactively you can `su circleci` and have postgres on your path
+echo 'export "PATH=/usr/lib/postgresql/${PG_MAJOR}/bin/:${PATH}"' >> ~circleci/.bashrc 
+
 echo "Running apt-get update..." >&2
 apt-get update
 apt-get install -y --no-install-recommends \
@@ -70,6 +73,12 @@ chmod o+w -R /usr/
 # install gosu so that we can run tests from root with circleci user
 apt-get install -y gosu
 
+# some tests rely on da_DK locale being available
+cat <<EOF >> /etc/locale.gen
+da_DK.UTF-8 UTF-8
+da_DK ISO-8859-1
+EOF
+locale-gen
 
 # keep that image size small!
 echo "Cleaning up..." >&2

--- a/circleci/images/exttester/files/sbin/install-testdeps
+++ b/circleci/images/exttester/files/sbin/install-testdeps
@@ -73,7 +73,7 @@ chmod o+w -R /usr/
 # install gosu so that we can run tests from root with circleci user
 apt-get install -y gosu
 
-# some tests rely on da_DK locale being available
+# some tests in some repos rely on da_DK locale being available
 cat <<EOF >> /etc/locale.gen
 da_DK.UTF-8 UTF-8
 da_DK ISO-8859-1


### PR DESCRIPTION
For some tests in certain suites we use the `da_DK` locale. This patch adds them to our test containers.

While I was at it I have added the postgres bin dir to the path for easier scripting.