### PR TITLE
Failtester update requirement

### DIFF
--- a/circleci/images/citusupgradetester/files/etc/requirements.txt
+++ b/circleci/images/citusupgradetester/files/etc/requirements.txt
@@ -9,7 +9,6 @@ certifi==2019.9.11
 cffi==1.12.3
 click==6.7
 construct==2.9.45
-cryptography==2.3.1
 docopt==0.6.2
 h11==0.7.0
 h2==3.1.1

--- a/circleci/images/failtester/files/etc/requirements.txt
+++ b/circleci/images/failtester/files/etc/requirements.txt
@@ -2,31 +2,42 @@
 # generated from Citus's Pipfile.lock (in src/test/regress) as of 1f4f6ea0
 # using `pipenv lock --requirements > requirements.txt`, so as to avoid the
 # need for pipenv/pyenv in this image
-asn1crypto==0.24.0
+asgiref==3.3.0
 blinker==1.4
-brotlipy==0.7.0
-certifi==2018.4.16
-cffi==1.11.5
-click==6.7
+brotli==1.0.9
+certifi==2020.6.20
+cffi==1.14.3
+click==7.1.2
 construct==2.9.45
-cryptography==2.3
-h11==0.7.0
-h2==3.0.1
-hpack==3.0.0
-hyperframe==5.1.0
-idna==2.7
-kaitaistruct==0.8
-ldap3==2.5
-mitmproxy==4.0.4
-passlib==1.7.1
-pyasn1==0.4.4
-pycparser==2.18
-pyopenssl==18.0.0
-pyparsing==2.2.0
-pyperclip==1.6.4
-ruamel.yaml==0.15.47
-six==1.11.0
-sortedcontainers==2.0.4
-tornado==5.1
-urwid==2.0.1
-wsproto==0.11.0
+cryptography==3.2.1
+dataclasses==0.7 ; python_version < '3.7'
+docopt==0.6.2
+flask==1.1.2
+h11==0.11.0
+h2==4.0.0 ; python_version >= '3.6.0'
+hpack==4.0.0
+hyperframe==6.0.0 ; python_version >= '3.6.0'
+itsdangerous==1.1.0
+jinja2==2.11.2
+kaitaistruct==0.9
+ldap3==2.8.1
+markupsafe==1.1.1
+mitmproxy==5.3.0
+msgpack==1.0.0
+passlib==1.7.4
+protobuf==3.13.0
+publicsuffix2==2.20191221
+pyasn1==0.4.8
+pycparser==2.20
+pyopenssl==19.1.0
+pyparsing==2.4.7
+pyperclip==1.8.1
+ruamel.yaml.clib==0.2.2 ; platform_python_implementation == 'CPython' and python_version < '3.9'
+ruamel.yaml==0.16.12
+six==1.15.0
+sortedcontainers==2.2.2
+tornado==6.1
+urwid==2.1.2
+werkzeug==1.0.1
+wsproto==0.15.0
+zstandard==0.14.0

--- a/circleci/images/failtester/files/sbin/install-testdeps
+++ b/circleci/images/failtester/files/sbin/install-testdeps
@@ -40,16 +40,6 @@ echo "Writing /etc/apt/sources.list.d/pgdg.list..." >&2
 echo "deb http://apt.postgresql.org/pub/repos/apt/ ${codename}-pgdg main ${pg_latest}" > \
      /etc/apt/sources.list.d/pgdg.list  
 
-pkg_cloud_url="https://packagecloud.io/install/repositories/citus-bot/the-process/script.deb.sh"
-
-curl -sf "${pkg_cloud_url}" | unique_id=exttester bash
-
-cat > /etc/apt/preferences.d/citusdata_the-process.pref <<EOF
-Package: postgresql-server-dev-*
-Pin: release o=packagecloud.io/citus-bot/the-process
-Pin-Priority: 700
-EOF
-
 echo "Installing tools for testing PostgreSQL extensions..." >&2
 apt-get update && apt-get install -y --no-install-recommends make postgresql-common \
  perl libcurl3 "postgresql-${PG_MAJOR}" "postgresql-server-dev-${PG_MAJOR}"

--- a/circleci/images/pgupgradetester/files/etc/requirements.txt
+++ b/circleci/images/pgupgradetester/files/etc/requirements.txt
@@ -2,32 +2,43 @@
 # generated from Citus's Pipfile.lock (in src/test/regress) as of 1f84056b83dcddf41346631ef327a8d9c772d17a
 # using `pipenv lock --requirements > requirements.txt`, so as to avoid the
 # need for pipenv/pyenv in this image
-asn1crypto==0.24.0
+asgiref==3.3.0
 blinker==1.4
-brotlipy==0.7.0
-certifi==2019.9.11
-cffi==1.12.3
-click==6.7
+brotli==1.0.9
+certifi==2020.6.20
+cffi==1.14.3
+click==7.1.2
 construct==2.9.45
-cryptography==2.3.1
+cryptography==3.2.1
+dataclasses==0.7 ; python_version < '3.7'
 docopt==0.6.2
-h11==0.7.0
-h2==3.1.1
-hpack==3.0.0
-hyperframe==5.2.0
-idna==2.8
-kaitaistruct==0.8
-ldap3==2.5.2
-mitmproxy==4.0.4
-passlib==1.7.1
-pyasn1==0.4.7
-pycparser==2.19
-pyopenssl==18.0.0
-pyparsing==2.2.2
-pyperclip==1.6.5
-ruamel.yaml==0.15.100
-six==1.12.0
-sortedcontainers==2.0.5
-tornado==5.1.1
-urwid==2.0.1
-wsproto==0.11.0
+flask==1.1.2
+h11==0.11.0
+h2==4.0.0 ; python_version >= '3.6.0'
+hpack==4.0.0
+hyperframe==6.0.0 ; python_version >= '3.6.0'
+itsdangerous==1.1.0
+jinja2==2.11.2
+kaitaistruct==0.9
+ldap3==2.8.1
+markupsafe==1.1.1
+mitmproxy==5.3.0
+msgpack==1.0.0
+passlib==1.7.4
+protobuf==3.13.0
+publicsuffix2==2.20191221
+pyasn1==0.4.8
+pycparser==2.20
+pyopenssl==19.1.0
+pyparsing==2.4.7
+pyperclip==1.8.1
+ruamel.yaml.clib==0.2.2 ; platform_python_implementation == 'CPython' and python_version < '3.9'
+ruamel.yaml==0.16.12
+six==1.15.0
+sortedcontainers==2.2.2
+tornado==6.1
+urwid==2.1.2
+werkzeug==1.0.1
+wsproto==0.15.0
+zstandard==0.14.0
+


### PR DESCRIPTION
requirements.txt also exist for pgupgradetester and citusupgradetester images. We can update them but the updated packages are not used by those containers so it should be fine to not update them.