### PR TITLE
Use 11-12-13 tag for pg upgrade tester

### DIFF
--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -112,12 +112,12 @@ build-pgupgradetester:
 		pgupgradetester/ \
 		-f pgupgradetester/Dockerfile \
 		--build-arg=PG_VERSIONS="${PG_VERSIONS}" \
-		--tag=${DOCKER_REPO}/pgupgradetester:latest${TAG_SUFFIX}
+		--tag=${DOCKER_REPO}/pgupgradetester:11-12-13${TAG_SUFFIX}
 
 build-all:: build-pgupgradetester
 
 push-pgupgradetester: build-pgupgradetester
-	docker push ${DOCKER_REPO}/pgupgradetester:latest${TAG_SUFFIX}
+	docker push ${DOCKER_REPO}/pgupgradetester:11-12-13${TAG_SUFFIX}
 
 push-all:: push-pgupgradetester
 


### PR DESCRIPTION
When we use latest tag for an image, it makes it harder to maintain old
branches that were depending on an old image, so it makes sense to have
a version that is more specific so that when we upgrade we can change
the tag and the old tag still exists.