### PR TITLE
add dependencies for running the postgres tap infrastructure

### DIFF
--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -82,6 +82,7 @@ RUN apt-get update \
     autoconf \
     build-essential \
     ca-certificates \
+    cpanminus \
     curl \
     debian-archive-keyring \
     gcc \
@@ -103,6 +104,9 @@ RUN apt-get update \
     perl \
 # clear apt cache
  && rm -rf /var/lib/apt/lists/*
+
+# perl's lib IPC::Run is required to run tap tests
+RUN cpanm install IPC::Run
 
 # make special locales available
 COPY locale.gen /etc/locale.gen


### PR DESCRIPTION
To be able to run postgres' tap test framework we need to have the `IPC::Run` library for perl installed in our test container. Since this package is not directly installable from `apt` we install `cpanminus` that comes with/is an installer for perl modules.

Subsequently we install the required perl library.