### PR TITLE
Update citus upgrade tester image

### DIFF
--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -9,11 +9,11 @@ else
 endif
 
 # all postgres versions we test against
-PG_VERSIONS = 11.9 12.4 13.0
+PG_VERSIONS = 12.4 13.0
 
-# citus version 8.x only supports 11, when bumping versions below we can create more images
-CITUS_UPGRADE_PG_VERSIONS = 11.9
-CITUS_UPGRADE_VERSIONS = v8.0.0 v8.1.0 v8.2.0 v8.3.0
+# we should add more majors/citus versions when we address https://github.com/citusdata/citus/issues/4807
+CITUS_UPGRADE_PG_VERSIONS = 12.4 
+CITUS_UPGRADE_VERSIONS = v9.0.0
 
 # code below creates targets for all postgres versions in PG_VERSIONS
 define make-image-targets


### PR DESCRIPTION
We dropped pg 11 support hence we remove it from the images.

We should add more citus upgrade tester images and it should be done when we address this issue https://github.com/citusdata/citus/issues/4807