### PR TITLE
Fix the installation of postgres when more then 1 release is available

### DIFF
--- a/circleci/images/citusupgradetester/Dockerfile
+++ b/circleci/images/citusupgradetester/Dockerfile
@@ -47,7 +47,7 @@ ENV PG_MAJOR=$PG_MAJOR
 RUN echo "deb https://apt-archive.postgresql.org/pub/repos/apt stretch-pgdg-archive main" > /etc/apt/sources.list.d/postgresql.list \
  && apt-get update \
 # infer the pgdgversion of postgres based on the $PG_VERSION
- && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}') \
+ && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ) \
  && apt-get install -y --no-install-recommends \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}=${pgdg_version} \

--- a/circleci/images/extbuilder/Dockerfile
+++ b/circleci/images/extbuilder/Dockerfile
@@ -44,7 +44,7 @@ ENV PG_MAJOR=$PG_MAJOR
 RUN echo "deb https://apt-archive.postgresql.org/pub/repos/apt stretch-pgdg-archive main" > /etc/apt/sources.list.d/postgresql.list \
  && apt-get update \
 # infer the pgdgversion of postgres based on the $PG_VERSION
- && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}') \
+ && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ) \
  && apt-get install -y --no-install-recommends \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}=${pgdg_version} \

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -126,7 +126,7 @@ ENV PG_MAJOR=$PG_MAJOR
 RUN echo "deb https://apt-archive.postgresql.org/pub/repos/apt stretch-pgdg-archive main" > /etc/apt/sources.list.d/postgresql.list \
  && apt-get update \
 # infer the pgdgversion of postgres based on the $PG_VERSION
- && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}') \
+ && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ) \
  && apt-get install -y --no-install-recommends \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}=${pgdg_version} \

--- a/circleci/images/failtester/Dockerfile
+++ b/circleci/images/failtester/Dockerfile
@@ -47,7 +47,7 @@ ENV PG_MAJOR=$PG_MAJOR
 RUN echo "deb https://apt-archive.postgresql.org/pub/repos/apt stretch-pgdg-archive main" > /etc/apt/sources.list.d/postgresql.list \
  && apt-get update \
 # infer the pgdgversion of postgres based on the $PG_VERSION
- && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}') \
+ && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ) \
  && apt-get install -y --no-install-recommends \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}=${pgdg_version} \

--- a/circleci/images/pgupgradetester/Dockerfile
+++ b/circleci/images/pgupgradetester/Dockerfile
@@ -48,7 +48,7 @@ RUN echo "deb https://apt-archive.postgresql.org/pub/repos/apt stretch-pgdg-arch
  && pkgs=(); \
     for PG_VERSION in $PG_VERSIONS; do \
         PG_MAJOR=$(echo ${PG_VERSION} | awk -F'[^0-9]*' '/[0-9]/ { print $1 }'); \
-        pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}'); \
+        pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ); \
         pkgs+=("postgresql-client-${PG_MAJOR}=${pgdg_version}"); \
         pkgs+=("postgresql-${PG_MAJOR}=${pgdg_version}"); \
         pkgs+=("postgresql-server-dev-${PG_MAJOR}=${pgdg_version}"); \


### PR DESCRIPTION
For postgres 13.4 there are 2 concurrent released versions:
 - 13.4-1
 - 13.4-4

The bash pipeline to infer the version to use had troubles parsing the versions
with more than 1 package per postgres minor version.

This PR changes the bash pipeline to correctly choose 1. For now we just take
the first one it finds with the use of `head -n1`.