### PR TITLE
Adds docker image build & publish pipeline

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -11,8 +11,39 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_package:
-    name: build-test-images
+  build_dev_images:
+    if: github.ref_name != 'master'
+    name: push-test-images-for-dev
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        command:
+          - extbuilder
+          - exttester
+          - failtester
+          - citusupgradetester
+          - pgupgradetester
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER_NAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      # If current branch is not master,build and publish dev image
+      - name: Build & Push all dev images
+        run: |
+          cd circleci/images
+          make push-${{ matrix.command }}-all
+
+  build_release_images:
+    if: github.ref_name == 'master'
+    name: push-test-images-for-release
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -27,13 +58,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER_NAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      # If current branch is not master,build and publish dev image
-      - name: Build & Push all dev images
-        if: ${{github.ref_name != env.MAIN_BRANCH_NAME }}
-        run: |
-          cd circleci/images
-          make push-all
-      # If current branch is not ,build and publish live image
+#      # If current branch is not ,build and publish live image
       - name: Build & Push all live images
         if: ${{github.ref_name == env.MAIN_BRANCH_NAME }}
         run: |

--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -1,0 +1,41 @@
+name: build-test-images
+env:
+  DOCKERHUB_USER_NAME: ${{ secrets.DOCKERHUB_USER_NAME }}
+  DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+  MAIN_BRANCH_NAME: master
+on:
+  push:
+    branches:
+      - "**"
+
+  workflow_dispatch:
+
+jobs:
+  build_package:
+    name: build-test-images
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER_NAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      # If current branch is not master,build and publish dev image
+      - name: Build & Push all dev images
+        if: ${{github.ref_name != env.MAIN_BRANCH_NAME }}
+        run: |
+          cd circleci/images
+          make push-all
+      # If current branch is not ,build and publish live image
+      - name: Build & Push all live images
+        if: ${{github.ref_name == env.MAIN_BRANCH_NAME }}
+        run: |
+          cd circleci/images
+          RELEASE=1 make push-all

--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -1,8 +1,4 @@
 name: build-test-images
-env:
-  DOCKERHUB_USER_NAME: ${{ secrets.DOCKERHUB_USER_NAME }}
-  DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
-  MAIN_BRANCH_NAME: master
 on:
   push:
     branches:
@@ -58,7 +54,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER_NAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-#      # If current branch is not ,build and publish live image
       - name: Build & Push all live images
         if: ${{github.ref_name == env.MAIN_BRANCH_NAME }}
         run: |

--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -1,11 +1,12 @@
 # config variable
 DOCKER_REPO ?= citus
+SHA_SUFFIX := $(shell git rev-parse --short HEAD)
 
 # auto generated variables
 ifdef RELEASE
-	TAG_SUFFIX := -v$(shell date +'%Y_%m_%d')
+	TAG_SUFFIX := -v${SHA_SUFFIX}
 else
-	TAG_SUFFIX := -dev-$(shell date +'%Y%m%d%H%M')
+	TAG_SUFFIX := -dev-${SHA_SUFFIX}
 endif
 
 # all postgres versions we test against

--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -122,8 +122,8 @@ build-pgupgradetester:
 
 build-all:: build-pgupgradetester
 
-push-pgupgradetester: build-pgupgradetester
+push-pgupgradetester-all: build-pgupgradetester
 	docker push ${DOCKER_REPO}/pgupgradetester:${PG_UPGRADE_TESTER_VERSION}${TAG_SUFFIX}
 
-push-all:: push-pgupgradetester
+push-all:: push-pgupgradetester-all
 


### PR DESCRIPTION
Building images locally may be cumbersome since downloading and pushing takes too much time and resource even sometimes interrupted because of PC resource problems. This pipeline adds development image with suffix when current branch is not master, i.e. PR is still open for the development of images, adds a live image without suffix.
To make the development images parallel I added a sha suffix to make the parallel images have the same suffix