### PR TITLE
Remove PG12 from upgrade images

### DIFF
--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -10,14 +10,14 @@ else
 endif
 
 # all postgres versions we test against
-PG_VERSIONS=12.9 13.5 14.1
+PG_VERSIONS=13.4 14.0
 
 PG_UPGRADE_TESTER_VERSION=$(shell echo ${PG_VERSIONS}|tr ' ' '-')
 
 
 # we should add more majors/citus versions when we address https://github.com/citusdata/citus/issues/4807
-CITUS_UPGRADE_PG_VERSIONS=12.9
-CITUS_UPGRADE_VERSIONS=v9.0.0 v10.1.0
+CITUS_UPGRADE_PG_VERSIONS=13.4
+CITUS_UPGRADE_VERSIONS=v9.5.0 v10.1.0
 
 # code below creates targets for all postgres versions in PG_VERSIONS
 define make-image-targets


### PR DESCRIPTION
We also need to rollback some PG versions as the necessary development (https://github.com/citusdata/citus/pull/5505) is not still finished on Citus.

Sister PR: https://github.com/citusdata/citus/pull/5842