### PR TITLE
Add pg15 beta1 to our CI images

### DIFF
--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -10,7 +10,7 @@ else
 endif
 
 # all postgres versions we test against
-PG_VERSIONS=13.4 14.0
+PG_VERSIONS=13.4 14.0 15~beta1
 
 PG_UPGRADE_TESTER_VERSION=$(shell echo ${PG_VERSIONS}|tr ' ' '-')
 

--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -12,7 +12,7 @@ endif
 # all postgres versions we test against
 PG_VERSIONS=13.4 14.0 15~beta1
 
-PG_UPGRADE_TESTER_VERSION=$(shell echo ${PG_VERSIONS}|tr ' ' '-')
+PG_UPGRADE_TESTER_VERSION=$(shell echo ${PG_VERSIONS}|tr ' ' '-'|sed 's/~//g')
 
 
 # we should add more majors/citus versions when we address https://github.com/citusdata/citus/issues/4807


### PR DESCRIPTION
In preparation of the postgres 15 release we need the first released beta version in CI to compile and test Citus against. This change adds the postgres 15~beta1 release to our testing matrix.