### PR TITLE
Stable libpq

### DIFF
--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -10,7 +10,7 @@ else
 endif
 
 # all postgres versions we test against
-PG_VERSIONS=13.4 14.0 15~beta1
+PG_VERSIONS=13.4 14.0
 
 PG_UPGRADE_TESTER_VERSION=$(shell echo ${PG_VERSIONS}|tr ' ' '-'|sed 's/~//g')
 

--- a/circleci/images/citusupgradetester/Dockerfile
+++ b/circleci/images/citusupgradetester/Dockerfile
@@ -51,7 +51,9 @@ RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /e
  && apt-get update \
 # infer the pgdgversion of postgres based on the $PG_VERSION
  && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ) \
- && apt-get install -y --no-install-recommends \
+ && apt-get install -y --no-install-recommends --allow-downgrades \
+    libpq-dev=${pgdg_version} \
+    libpq5=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \

--- a/circleci/images/extbuilder/Dockerfile
+++ b/circleci/images/extbuilder/Dockerfile
@@ -46,7 +46,9 @@ RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /e
  && apt-get update \
 # infer the pgdgversion of postgres based on the $PG_VERSION
  && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ) \
- && apt-get install -y --no-install-recommends \
+ && apt-get install -y --no-install-recommends --allow-downgrades \
+    libpq-dev=${pgdg_version} \
+    libpq5=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -128,7 +128,9 @@ RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /e
  && apt-get update \
 # infer the pgdgversion of postgres based on the $PG_VERSION
  && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ) \
- && apt-get install -y --no-install-recommends \
+ && apt-get install -y --no-install-recommends --allow-downgrades \
+    libpq-dev=${pgdg_version} \
+    libpq5=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \

--- a/circleci/images/failtester/Dockerfile
+++ b/circleci/images/failtester/Dockerfile
@@ -50,7 +50,9 @@ RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /e
  && apt-get update \
 # infer the pgdgversion of postgres based on the $PG_VERSION
  && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ) \
- && apt-get install -y --no-install-recommends \
+ && apt-get install -y --no-install-recommends --allow-downgrades \
+    libpq-dev=${pgdg_version} \
+    libpq5=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \

--- a/circleci/images/pgupgradetester/Dockerfile
+++ b/circleci/images/pgupgradetester/Dockerfile
@@ -53,9 +53,12 @@ RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /e
         pkgs+=("postgresql-client-${PG_MAJOR}=${pgdg_version}"); \
         pkgs+=("postgresql-${PG_MAJOR}=${pgdg_version}"); \
         pkgs+=("postgresql-server-dev-${PG_MAJOR}=${pgdg_version}"); \
+        last_pgdg_version=$pgdg_version; \
     done; \
+    pkgs+=("libpq-dev=${last_pgdg_version}"); \
+    pkgs+=("libpq5=${last_pgdg_version}"); \
     echo ${pkgs[@]}\
- && apt-get install -y --no-install-recommends \
+ && apt-get install -y --no-install-recommends --allow-downgrades \
     postgresql-common \
     ${pkgs[@]} \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
In the old images it would always ship with the latest version of libpq. This would have the downside that 

1. it was hard to reproduce the expected test outputs locally, since locally we switch libpq together with the postgres minor version
2. every time we would rebuild an image it could break the expected test output

To make it easier to add newer versions of postgres and/or rebuild images at a later point in time, as well as have passing tests locally we are changing CI in a way such that the libpq version is pinned to the same postgres minor version as the postgres server.

To make it easier to integrate this into our CI we need to remove the 15beta1 images again. Since that supresses the upgrade image to be made in a backwards compatible manner.

Upside is that after this patch it will be easier to actually add 15 beta1 ( or most likely beta2 ) to our CI pipeline, in preparation for the release later this year.