### PR TITLE
Add 15beta2 CI images

### DIFF
--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -10,7 +10,7 @@ else
 endif
 
 # all postgres versions we test against
-PG_VERSIONS=13.4 14.0
+PG_VERSIONS=13.4 14.0 15~beta2
 
 PG_UPGRADE_TESTER_VERSION=$(shell echo ${PG_VERSIONS}|tr ' ' '-'|sed 's/~//g')
 


### PR DESCRIPTION
This PR is an alternative to #80 as it was not so easy to fix all the failures after we bump all PG minor versions to latest. Instead, we only add `PG15beta2` to the CI images, and keep the change minimal.

Closes: #80 