### PR TITLE
Upgrade citus tools version to 0.8.18 for stylechecker

### DIFF
--- a/circleci/images/stylechecker/Dockerfile
+++ b/circleci/images/stylechecker/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.9
-ARG TOOLS_VERSION=0.7.9
+ARG TOOLS_VERSION=0.8.18
 
 RUN apk add --no-cache --virtual installdeps curl make sed && \
     apk add --no-cache \


### PR DESCRIPTION
The purpose of this is to properly format & when used to define reference types in cpp.
For more see: https://github.com/citusdata/tools/commit/1ab6a8e33b43df446a5739f72807cf7ecd4e8d42