### PR TITLE
Add network tools to failtester image

### DIFF
--- a/circleci/images/failtester/Dockerfile
+++ b/circleci/images/failtester/Dockerfile
@@ -27,7 +27,9 @@ RUN apt-get update \
     libzstd-dev \
     libzstd1 \
     locales \
+    lsof \
     make \
+    net-tools \
     perl \
 # clear apt cache
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Setting up mitmproxy uses lsof and netstat. The were always used already
but not having lsof becomes a hard  failure with https://github.com/citusdata/citus/pull/6205