### PR TITLE
Fix/python protobuf

### DIFF
--- a/circleci/images/citusupgradetester/files/etc/requirements.txt
+++ b/circleci/images/citusupgradetester/files/etc/requirements.txt
@@ -25,7 +25,7 @@ ldap3==2.9.1
 markupsafe==2.0.1; python_version >= '3.6'
 msgpack==1.0.2
 passlib==1.7.4
-protobuf==3.18.1; python_version >= '3.5'
+protobuf==3.18.3; python_version >= '3.5'
 publicsuffix2==2.20191221
 pyasn1==0.4.8
 pycparser==2.20; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'

--- a/circleci/images/failtester/files/etc/requirements.txt
+++ b/circleci/images/failtester/files/etc/requirements.txt
@@ -25,7 +25,7 @@ ldap3==2.9.1
 markupsafe==2.0.1; python_version >= '3.6'
 msgpack==1.0.2
 passlib==1.7.4
-protobuf==3.18.1; python_version >= '3.5'
+protobuf==3.18.3; python_version >= '3.5'
 publicsuffix2==2.20191221
 pyasn1==0.4.8
 pycparser==2.20; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'

--- a/circleci/images/pgupgradetester/files/etc/requirements.txt
+++ b/circleci/images/pgupgradetester/files/etc/requirements.txt
@@ -24,7 +24,7 @@ markupsafe==2.0.1; python_version >= '3.6'
 mitmproxy==7.0.4
 msgpack==1.0.2
 passlib==1.7.4
-protobuf==3.18.0
+protobuf==3.18.3
 publicsuffix2==2.20191221
 pyasn1==0.4.8
 pycparser==2.20; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'


### PR DESCRIPTION
Bumps versions of protobuf to a non-vulnerable version.

Closes: #89 #90 #91