### PR TITLE
Add lcov and gdb

### DIFF
--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update \
     gcc \
     gnupg \
     gosu \
+    lcov \
     libcurl4 \
     libcurl4-openssl-dev \
     libicu-dev \

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update \
     curl \
     debian-archive-keyring \
     gcc \
+    gdb \
     gnupg \
     gosu \
     lcov \


### PR DESCRIPTION
This adds `lcov` and `gdb` to our exttester images. `lcov` is needed to test
codeclimate for coverage and `gdb` is needed to show stacktraces of coredumps.
