### PR TITLE
Prepare test images for coredumps and codeclimate

### DIFF
--- a/circleci/images/citusupgradetester/Dockerfile
+++ b/circleci/images/citusupgradetester/Dockerfile
@@ -12,9 +12,11 @@ RUN apt-get update \
     ca-certificates \
     curl \
     debian-archive-keyring \
+    gdb \
     git \
     gnupg \
     gosu \
+    lcov \
     libcurl4 \
     libcurl4-openssl-dev \
     libicu-dev \

--- a/circleci/images/citusupgradetester/Dockerfile
+++ b/circleci/images/citusupgradetester/Dockerfile
@@ -40,7 +40,7 @@ COPY locale.gen /etc/locale.gen
 RUN locale-gen
 
 # Add codeclimate
-RUN mkdir -p codeclimate/ && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./codeclimate/test-reporter && chmod +x ./codeclimate/test-reporter
+RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter && chmod +x /usr/local/bin/cc-test-reporter
 
 # add postgres signing key
 RUN curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -

--- a/circleci/images/citusupgradetester/Dockerfile
+++ b/circleci/images/citusupgradetester/Dockerfile
@@ -39,6 +39,9 @@ RUN apt-get update \
 COPY locale.gen /etc/locale.gen
 RUN locale-gen
 
+# Add codeclimate
+RUN mkdir -p codeclimate/ && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./codeclimate/test-reporter && chmod +x ./codeclimate/test-reporter
+
 # add postgres signing key
 RUN curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
 

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -116,6 +116,9 @@ RUN cpanm install IPC::Run
 COPY locale.gen /etc/locale.gen
 RUN locale-gen
 
+# Add codeclimate
+RUN mkdir -p codeclimate/ && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./codeclimate/test-reporter && chmod +x ./codeclimate/test-reporter
+
 # add postgres signing key
 RUN curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
 

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -12,10 +12,8 @@ RUN apt-get update \
     curl \
     debian-archive-keyring \
     gcc \
-    gdb \
     gnupg \
     gosu \
-    lcov \
     libcurl4 \
     libcurl4-openssl-dev \
     libicu-dev \
@@ -90,8 +88,10 @@ RUN apt-get update \
     curl \
     debian-archive-keyring \
     gcc \
+    gdb \
     gnupg \
     gosu \
+    lcov \
     libcurl4 \
     libcurl4-openssl-dev \
     libicu-dev \

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -117,7 +117,7 @@ COPY locale.gen /etc/locale.gen
 RUN locale-gen
 
 # Add codeclimate
-RUN mkdir -p codeclimate/ && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./codeclimate/test-reporter && chmod +x ./codeclimate/test-reporter
+RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter && chmod +x /usr/local/bin/cc-test-reporter
 
 # add postgres signing key
 RUN curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -

--- a/circleci/images/failtester/Dockerfile
+++ b/circleci/images/failtester/Dockerfile
@@ -12,9 +12,11 @@ RUN apt-get update \
     ca-certificates \
     curl \
     debian-archive-keyring \
+    gdb \
     git \
     gnupg \
     gosu \
+    lcov \
     libcurl4 \
     libcurl4-openssl-dev \
     libicu-dev \

--- a/circleci/images/failtester/Dockerfile
+++ b/circleci/images/failtester/Dockerfile
@@ -41,7 +41,7 @@ COPY locale.gen /etc/locale.gen
 RUN locale-gen
 
 # Add codeclimate
-RUN mkdir -p codeclimate/ && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./codeclimate/test-reporter && chmod +x ./codeclimate/test-reporter
+RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter && chmod +x /usr/local/bin/cc-test-reporter
 
 # add postgres signing key
 RUN curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -

--- a/circleci/images/failtester/Dockerfile
+++ b/circleci/images/failtester/Dockerfile
@@ -40,6 +40,9 @@ RUN apt-get update \
 COPY locale.gen /etc/locale.gen
 RUN locale-gen
 
+# Add codeclimate
+RUN mkdir -p codeclimate/ && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./codeclimate/test-reporter && chmod +x ./codeclimate/test-reporter
+
 # add postgres signing key
 RUN curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
 

--- a/circleci/images/pgupgradetester/Dockerfile
+++ b/circleci/images/pgupgradetester/Dockerfile
@@ -12,8 +12,10 @@ RUN apt-get update \
     ca-certificates \
     curl \
     debian-archive-keyring \
+    gdb \
     gnupg \
     gosu \
+    lcov \
     libcurl4 \
     libcurl4-openssl-dev \
     libicu-dev \

--- a/circleci/images/pgupgradetester/Dockerfile
+++ b/circleci/images/pgupgradetester/Dockerfile
@@ -33,6 +33,9 @@ RUN apt-get update \
 # clear apt cache
  && rm -rf /var/lib/apt/lists/*
 
+# Add codeclimate
+RUN mkdir -p codeclimate/ && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./codeclimate/test-reporter && chmod +x ./codeclimate/test-reporter
+
  # add postgres signing key
 RUN curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
 

--- a/circleci/images/pgupgradetester/Dockerfile
+++ b/circleci/images/pgupgradetester/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update \
     curl \
     debian-archive-keyring \
     gdb \
+    git \
     gnupg \
     gosu \
     lcov \

--- a/circleci/images/pgupgradetester/Dockerfile
+++ b/circleci/images/pgupgradetester/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # Add codeclimate
-RUN mkdir -p codeclimate/ && curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./codeclimate/test-reporter && chmod +x ./codeclimate/test-reporter
+RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter && chmod +x /usr/local/bin/cc-test-reporter
 
  # add postgres signing key
 RUN curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -


### PR DESCRIPTION
I added gdb and lcov previously, but added them to the layer that
compiles postgres instead of the layer that is used for testing...
This fixes that. 

It also adds a few more things that were necessary for codeclimate.
Such as git and the codeclimate binary.

Related PR that uses this can be found here: https://github.com/citusdata/citus/pull/6538
