### PR TITLE
add debug symbols into postgres build

### DIFF
--- a/circleci/images/citusupgradetester/Dockerfile
+++ b/circleci/images/citusupgradetester/Dockerfile
@@ -60,7 +60,7 @@ RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /e
     libpq-dev=${pgdg_version} \
     libpq5=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
-    postgresql-${PG_MAJOR}=${pgdg_version} \
+    postgresql-${PG_MAJOR}-dbgsym=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \
 # clear apt cache
  && rm -rf /var/lib/apt/lists/*

--- a/circleci/images/extbuilder/Dockerfile
+++ b/circleci/images/extbuilder/Dockerfile
@@ -50,7 +50,7 @@ RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /e
     libpq-dev=${pgdg_version} \
     libpq5=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
-    postgresql-${PG_MAJOR}=${pgdg_version} \
+    postgresql-${PG_MAJOR}-dbgsym=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \
 # clear apt cache
  && rm -rf /var/lib/apt/lists/*

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -137,7 +137,7 @@ RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /e
     libpq-dev=${pgdg_version} \
     libpq5=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
-    postgresql-${PG_MAJOR}=${pgdg_version} \
+    postgresql-${PG_MAJOR}-dbgsym=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \
 # clear apt cache
  && rm -rf /var/lib/apt/lists/*

--- a/circleci/images/failtester/Dockerfile
+++ b/circleci/images/failtester/Dockerfile
@@ -61,7 +61,7 @@ RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /e
     libpq-dev=${pgdg_version} \
     libpq5=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
-    postgresql-${PG_MAJOR}=${pgdg_version} \
+    postgresql-${PG_MAJOR}-dbgsym=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \
 # clear apt cache
  && rm -rf /var/lib/apt/lists/*

--- a/circleci/images/pgupgradetester/Dockerfile
+++ b/circleci/images/pgupgradetester/Dockerfile
@@ -57,7 +57,7 @@ RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /e
         PG_MAJOR=$(echo ${PG_VERSION} | awk -F'[^0-9]*' '/[0-9]/ { print $1 }'); \
         pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ); \
         pkgs+=("postgresql-client-${PG_MAJOR}=${pgdg_version}"); \
-        pkgs+=("postgresql-${PG_MAJOR}=${pgdg_version}"); \
+        pkgs+=("postgresql-${PG_MAJOR}-dbgsym=${pgdg_version}"); \
         pkgs+=("postgresql-server-dev-${PG_MAJOR}=${pgdg_version}"); \
         last_pgdg_version=$pgdg_version; \
     done; \


### PR DESCRIPTION
Adds debug symbols into Postgres build to print useful stack traces from core files.