### PR TITLE
Install grep in stylechecker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ This container is a special beast. Besides having the testing dependencies insta
 
 ### stylechecker
 
-TODO: this image has not changed and is currently not built by the Makefile. Future work.
+This image is a small alpine image that contains necessary tools to run various scripts in our CI environment. It is not based on any of the images listed here.

--- a/circleci/images/stylechecker/Dockerfile
+++ b/circleci/images/stylechecker/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add --no-cache --virtual installdeps curl make sed && \
         ca-certificates \
         bash \
         git \
+        grep \
         gzip \
         openssh \
         perl \


### PR DESCRIPTION
When we add some scripts to run in CI, it is a nice idea to use long argument names. However, the busybox grep binary in our images do not support long argument names, and hence we install GNU grep.

Used in: https://github.com/citusdata/citus/pull/6661