### PR TITLE
Install dev requirements in stylechecker

### DIFF
--- a/circleci/images/stylechecker/Dockerfile
+++ b/circleci/images/stylechecker/Dockerfile
@@ -1,22 +1,41 @@
-FROM alpine:3.9
+FROM alpine:latest
 ARG TOOLS_VERSION
 
-RUN apk add --no-cache --virtual installdeps curl make sed && \
-    apk add --no-cache \
-        ca-certificates \
-        bash \
-        git \
-        grep \
-        gzip \
-        openssh \
-        perl \
-        tar \
-        uncrustify && \
-    curl -sfLO "https://github.com/citusdata/tools/archive/v${TOOLS_VERSION}.tar.gz" && \
-    tar xzf "v${TOOLS_VERSION}.tar.gz" && \
-    cd "tools-${TOOLS_VERSION}" && \
-    sed -i -e's/align_number_left/align_number_right/g' uncrustify/citus-style.cfg && \
-    make uncrustify/.install && \
-    cd .. && \
-    rm -rf "citus-${VERSION}" "v${TOOLS_VERSION}.tar.gz" && \
-    apk del installdeps
+COPY ./files/etc/requirements.txt /tmp/etc/
+# openssh is needed in the image for CircleCI to pull the repo over ssh
+RUN apk add --no-cache --virtual installdeps \
+      curl \
+      make \
+      cmake \
+      g++ \
+      gcc \
+      gzip \
+      musl-dev \
+      py3-pip \
+      python3-dev \
+      tar \
+  && apk add --no-cache \
+      ca-certificates \
+      bash \
+      git \
+      grep \
+      openssh \
+      perl \
+      python3 \
+      py3-packaging \
+  && curl -L "https://github.com/citusdata/tools/archive/v${TOOLS_VERSION}.tar.gz" | tar xz \
+  && cd "tools-${TOOLS_VERSION}" \
+  && make uncrustify/.install \
+  && cd .. \
+  && rm -rf "citus-${VERSION}" "v${TOOLS_VERSION}.tar.gz" \
+  && curl -L "https://github.com/uncrustify/uncrustify/archive/uncrustify-0.68.1.tar.gz" | tar xz \
+  && cd uncrustify-uncrustify-0.68.1/ \
+  && mkdir build \
+  && cd build \
+  && cmake .. \
+  && make -j5 \
+  && make install \
+  && cd ../.. \
+  && rm -rf uncrustify-uncrustify-0.68.1/ \
+  && pip3 install -Ir /tmp/etc/requirements.txt \
+  && apk del installdeps

--- a/circleci/images/stylechecker/files/etc/requirements.txt
+++ b/circleci/images/stylechecker/files/etc/requirements.txt
@@ -1,0 +1,55 @@
+# generated from Citus's Pipfile.lock (in src/test/regress) as of #6700
+# using `pipenv requirements --dev > requirements.txt`, so as to avoid the
+# need for pipenv/pyenv in this image
+
+-i https://pypi.python.org/simple
+attrs==22.2.0; python_version >= '3.6'
+black==23.1.0
+click==8.0.4; python_version >= '3.6'
+flake8==6.0.0
+flake8-bugbear==23.1.20
+isort==5.12.0
+mccabe==0.7.0; python_version >= '3.6'
+mypy-extensions==1.0.0; python_version >= '3.5'
+packaging==23.0; python_version >= '3.7'
+pathspec==0.11.0; python_version >= '3.7'
+platformdirs==3.0.0; python_version >= '3.7'
+pycodestyle==2.10.0; python_version >= '3.6'
+pyflakes==3.0.1; python_version >= '3.6'
+tomli==2.0.1; python_version < '3.11'
+asgiref==3.4.1; python_version >= '3.6'
+blinker==1.4
+brotli==1.0.9
+certifi==2022.12.7; python_version >= '3.6'
+cffi==1.15.1
+construct==2.9.45
+cryptography==3.4.8
+docopt==0.6.2
+flask==2.0.3; python_version >= '3.6'
+h11==0.12.0; python_version >= '3.6'
+h2==4.1.0; python_full_version >= '3.6.1'
+hpack==4.0.0; python_full_version >= '3.6.1'
+hyperframe==6.0.1; python_full_version >= '3.6.1'
+itsdangerous==2.1.2; python_version >= '3.7'
+jinja2==3.1.2; python_version >= '3.7'
+kaitaistruct==0.9
+ldap3==2.9.1
+markupsafe==2.1.2; python_version >= '3.7'
+-e git+https://github.com/thanodnl/mitmproxy.git@62798926288526d27221bdb618f526862a878e33#egg=mitmproxy
+msgpack==1.0.4
+passlib==1.7.4
+protobuf==3.18.3; python_version >= '3.5'
+publicsuffix2==2.20191221
+pyasn1==0.4.8
+pycparser==2.21; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pyopenssl==21.0.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pyperclip==1.8.2
+ruamel.yaml==0.17.16; python_version >= '3'
+six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+sortedcontainers==2.4.0
+tornado==6.2; python_version >= '3.7'
+urwid==2.1.2
+werkzeug==2.2.2; python_version >= '3.7'
+wsproto==1.0.0; python_full_version >= '3.6.1'
+zstandard==0.15.2; python_version >= '3.5'


### PR DESCRIPTION
Needed to check Python formatting and linting from CI for https://github.com/citusdata/citus/pull/6700

Since some of these tools need a somewhat recent python version this also required an update of the alpine base image. And to make that in turn work, we need to install `uncrustify` from source (just like we recommend devs to do).