### PR TITLE
Update vulnerable cryptography package

### DIFF
--- a/circleci/images/citusupgradetester/files/etc/requirements.txt
+++ b/circleci/images/citusupgradetester/files/etc/requirements.txt
@@ -1,43 +1,41 @@
-# generated from Citus's Pipfile.lock (in src/test/regress) as of f4297f7
-# using `pipenv lock --requirements > requirements.txt`, so as to avoid the
+# generated from Citus's Pipfile.lock (in src/test/regress) as of #6710
+# using `pipenv requirements > requirements.txt`, so as to avoid the
 # need for pipenv/pyenv in this image
 
 -i https://pypi.python.org/simple
--e git+https://github.com/thanodnl/mitmproxy.git@62798926288526d27221bdb618f526862a878e33#egg=mitmproxy
 asgiref==3.4.1; python_version >= '3.6'
 blinker==1.4
 brotli==1.0.9
-certifi==2021.10.8
-cffi==1.15.0
-click==8.0.3; python_version >= '3.6'
+certifi==2022.12.7; python_version >= '3.6'
+cffi==1.15.1
+click==8.0.4; python_version >= '3.6'
 construct==2.9.45
-cryptography==3.4.8
+cryptography==39.0.1
 docopt==0.6.2
-flask==2.0.2; python_version >= '3.6'
+flask==2.0.3; python_version >= '3.6'
 h11==0.12.0; python_version >= '3.6'
 h2==4.1.0; python_full_version >= '3.6.1'
 hpack==4.0.0; python_full_version >= '3.6.1'
 hyperframe==6.0.1; python_full_version >= '3.6.1'
-itsdangerous==2.0.1; python_version >= '3.6'
-jinja2==3.0.2; python_version >= '3.6'
+itsdangerous==2.1.2; python_version >= '3.7'
+jinja2==3.1.2; python_version >= '3.7'
 kaitaistruct==0.9
 ldap3==2.9.1
-markupsafe==2.0.1; python_version >= '3.6'
-msgpack==1.0.2
+markupsafe==2.1.2; python_version >= '3.7'
+-e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
+msgpack==1.0.4
 passlib==1.7.4
 protobuf==3.18.3; python_version >= '3.5'
 publicsuffix2==2.20191221
 pyasn1==0.4.8
-pycparser==2.20; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pyopenssl==21.0.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pycparser==2.21
+pyopenssl==23.0.0; python_version >= '3.6'
+pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 pyperclip==1.8.2
-ruamel.yaml.clib==0.2.6; python_version < '3.10' and platform_python_implementation == 'CPython'
 ruamel.yaml==0.17.16; python_version >= '3'
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sortedcontainers==2.4.0
-tornado==6.1; python_version >= '3.5'
+tornado==6.2; python_version >= '3.7'
 urwid==2.1.2
-werkzeug==2.0.2; python_version >= '3.6'
+werkzeug==2.2.2; python_version >= '3.7'
 wsproto==1.0.0; python_full_version >= '3.6.1'
 zstandard==0.15.2; python_version >= '3.5'

--- a/circleci/images/failtester/files/etc/requirements.txt
+++ b/circleci/images/failtester/files/etc/requirements.txt
@@ -1,43 +1,41 @@
-# generated from Citus's Pipfile.lock (in src/test/regress) as of f4297f7
-# using `pipenv lock --requirements > requirements.txt`, so as to avoid the
+# generated from Citus's Pipfile.lock (in src/test/regress) as of #6710
+# using `pipenv requirements > requirements.txt`, so as to avoid the
 # need for pipenv/pyenv in this image
 
 -i https://pypi.python.org/simple
--e git+https://github.com/thanodnl/mitmproxy.git@62798926288526d27221bdb618f526862a878e33#egg=mitmproxy
 asgiref==3.4.1; python_version >= '3.6'
 blinker==1.4
 brotli==1.0.9
-certifi==2021.10.8
-cffi==1.15.0
-click==8.0.3; python_version >= '3.6'
+certifi==2022.12.7; python_version >= '3.6'
+cffi==1.15.1
+click==8.0.4; python_version >= '3.6'
 construct==2.9.45
-cryptography==3.4.8
+cryptography==39.0.1
 docopt==0.6.2
-flask==2.0.2; python_version >= '3.6'
+flask==2.0.3; python_version >= '3.6'
 h11==0.12.0; python_version >= '3.6'
 h2==4.1.0; python_full_version >= '3.6.1'
 hpack==4.0.0; python_full_version >= '3.6.1'
 hyperframe==6.0.1; python_full_version >= '3.6.1'
-itsdangerous==2.0.1; python_version >= '3.6'
-jinja2==3.0.2; python_version >= '3.6'
+itsdangerous==2.1.2; python_version >= '3.7'
+jinja2==3.1.2; python_version >= '3.7'
 kaitaistruct==0.9
 ldap3==2.9.1
-markupsafe==2.0.1; python_version >= '3.6'
-msgpack==1.0.2
+markupsafe==2.1.2; python_version >= '3.7'
+-e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
+msgpack==1.0.4
 passlib==1.7.4
 protobuf==3.18.3; python_version >= '3.5'
 publicsuffix2==2.20191221
 pyasn1==0.4.8
-pycparser==2.20; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pyopenssl==21.0.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pycparser==2.21
+pyopenssl==23.0.0; python_version >= '3.6'
+pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 pyperclip==1.8.2
-ruamel.yaml.clib==0.2.6; python_version < '3.10' and platform_python_implementation == 'CPython'
 ruamel.yaml==0.17.16; python_version >= '3'
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sortedcontainers==2.4.0
-tornado==6.1; python_version >= '3.5'
+tornado==6.2; python_version >= '3.7'
 urwid==2.1.2
-werkzeug==2.0.2; python_version >= '3.6'
+werkzeug==2.2.2; python_version >= '3.7'
 wsproto==1.0.0; python_full_version >= '3.6.1'
 zstandard==0.15.2; python_version >= '3.5'

--- a/circleci/images/pgupgradetester/files/etc/requirements.txt
+++ b/circleci/images/pgupgradetester/files/etc/requirements.txt
@@ -1,42 +1,41 @@
--i https://pypi.python.org/simple
-# generated from Citus's Pipfile.lock (in src/test/regress) as of ...
-# using `pipenv lock --requirements > requirements.txt`, so as to avoid the
+# generated from Citus's Pipfile.lock (in src/test/regress) as of #6710
+# using `pipenv requirements > requirements.txt`, so as to avoid the
 # need for pipenv/pyenv in this image
+
+-i https://pypi.python.org/simple
 asgiref==3.4.1; python_version >= '3.6'
 blinker==1.4
 brotli==1.0.9
-certifi==2021.5.30
-cffi==1.14.6
-click==8.0.1; python_version >= '3.6'
+certifi==2022.12.7; python_version >= '3.6'
+cffi==1.15.1
+click==8.0.4; python_version >= '3.6'
 construct==2.9.45
-cryptography==3.4.8
+cryptography==39.0.1
 docopt==0.6.2
-flask==2.0.1; python_version >= '3.6'
+flask==2.0.3; python_version >= '3.6'
 h11==0.12.0; python_version >= '3.6'
-h2==4.0.0; python_full_version >= '3.6.1'
+h2==4.1.0; python_full_version >= '3.6.1'
 hpack==4.0.0; python_full_version >= '3.6.1'
 hyperframe==6.0.1; python_full_version >= '3.6.1'
-itsdangerous==2.0.1; python_version >= '3.6'
-jinja2==3.0.1; python_version >= '3.6'
+itsdangerous==2.1.2; python_version >= '3.7'
+jinja2==3.1.2; python_version >= '3.7'
 kaitaistruct==0.9
 ldap3==2.9.1
-markupsafe==2.0.1; python_version >= '3.6'
-mitmproxy==7.0.4
-msgpack==1.0.2
+markupsafe==2.1.2; python_version >= '3.7'
+-e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
+msgpack==1.0.4
 passlib==1.7.4
-protobuf==3.18.3
+protobuf==3.18.3; python_version >= '3.5'
 publicsuffix2==2.20191221
 pyasn1==0.4.8
-pycparser==2.20; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pyopenssl==20.0.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pycparser==2.21
+pyopenssl==23.0.0; python_version >= '3.6'
+pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 pyperclip==1.8.2
-ruamel.yaml.clib==0.2.6; python_version < '3.10' and platform_python_implementation == 'CPython'
 ruamel.yaml==0.17.16; python_version >= '3'
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sortedcontainers==2.4.0
-tornado==6.1; python_version >= '3.5'
+tornado==6.2; python_version >= '3.7'
 urwid==2.1.2
-werkzeug==2.0.1; python_version >= '3.6'
+werkzeug==2.2.2; python_version >= '3.7'
 wsproto==1.0.0; python_full_version >= '3.6.1'
 zstandard==0.15.2; python_version >= '3.5'

--- a/circleci/images/stylechecker/files/etc/requirements.txt
+++ b/circleci/images/stylechecker/files/etc/requirements.txt
@@ -1,4 +1,4 @@
-# generated from Citus's Pipfile.lock (in src/test/regress) as of #6700
+# generated from Citus's Pipfile.lock (in src/test/regress) as of #6710
 # using `pipenv requirements --dev > requirements.txt`, so as to avoid the
 # need for pipenv/pyenv in this image
 
@@ -23,7 +23,7 @@ brotli==1.0.9
 certifi==2022.12.7; python_version >= '3.6'
 cffi==1.15.1
 construct==2.9.45
-cryptography==3.4.8
+cryptography==39.0.1
 docopt==0.6.2
 flask==2.0.3; python_version >= '3.6'
 h11==0.12.0; python_version >= '3.6'
@@ -35,18 +35,17 @@ jinja2==3.1.2; python_version >= '3.7'
 kaitaistruct==0.9
 ldap3==2.9.1
 markupsafe==2.1.2; python_version >= '3.7'
--e git+https://github.com/thanodnl/mitmproxy.git@62798926288526d27221bdb618f526862a878e33#egg=mitmproxy
+-e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
 msgpack==1.0.4
 passlib==1.7.4
 protobuf==3.18.3; python_version >= '3.5'
 publicsuffix2==2.20191221
 pyasn1==0.4.8
-pycparser==2.21; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pyopenssl==21.0.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pycparser==2.21
+pyopenssl==23.0.0; python_version >= '3.6'
+pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'
 pyperclip==1.8.2
 ruamel.yaml==0.17.16; python_version >= '3'
-six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sortedcontainers==2.4.0
 tornado==6.2; python_version >= '3.7'
 urwid==2.1.2


### PR DESCRIPTION
Dependabot was complaining about this issue, which I addressed on the
main repo in [#6710]. But to actually make it effective in CI we need to
update our images too.

[#6710]: https://github.com/citusdata/citus/pull/6710