### PR TITLE
Install Rust in exttester

### DIFF
--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -110,7 +110,11 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # install rust
-RUN curl --proto '=https' --tlsv1.2 --silent --show-error https://sh.rustup.rs | sh -s -- -y
+RUN curl --proto '=https' --tlsv1.2 --silent --show-error https://sh.rustup.rs | sh -s -- -y \
+  && rustup install nightly \
+  && rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu \
+  && rustup default nightly
+
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # perl's lib IPC::Run is required to run tap tests

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -87,7 +87,6 @@ RUN apt-get update \
     cpanminus \
     curl \
     debian-archive-keyring \
-    expect \
     gcc \
     gdb \
     gnupg \

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -111,9 +111,9 @@ RUN apt-get update \
 
 # install rust
 RUN curl --proto '=https' --tlsv1.2 --silent --show-error https://sh.rustup.rs | sh -s -- -y \
-  && rustup install nightly \
-  && rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu \
-  && rustup default nightly
+  && /root/.cargo/bin/rustup install nightly \
+  && /root/.cargo/bin/rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu \
+  && /root/.cargo/bin/rustup default nightly
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -87,6 +87,7 @@ RUN apt-get update \
     cpanminus \
     curl \
     debian-archive-keyring \
+    expect \
     gcc \
     gdb \
     gnupg \

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -111,11 +111,7 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # install rust
-RUN curl --proto '=https' --tlsv1.2 --silent --show-error https://sh.rustup.rs | sh -s -- -y \
-  && /root/.cargo/bin/rustup install nightly \
-  && /root/.cargo/bin/rustup component add rust-src --toolchain nightly-x86_64-unknown-linux-gnu \
-  && /root/.cargo/bin/rustup default nightly
-
+RUN curl --proto '=https' --tlsv1.2 --silent --show-error https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
 # perl's lib IPC::Run is required to run tap tests

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -109,6 +109,10 @@ RUN apt-get update \
 # clear apt cache
  && rm -rf /var/lib/apt/lists/*
 
+# install rust
+RUN curl --proto '=https' --tlsv1.2 --silent --show-error https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 # perl's lib IPC::Run is required to run tap tests
 RUN cpanm install IPC::Run
 


### PR DESCRIPTION
https://github.com/citusdata/pgazure/pull/167 depends on a working Rust environment in a CI image.

We actually need some more tools and configurations in the images, but I intentionally did that in the project CI configs. Several benefits:
1. I do not make it considerably harder to locally build images.
2. The generated public docker images do not contain MS tools that are not really open.
3. We have a decreased attack surface considering we still do not access ADO in this repo. 