### PR TITLE
Fix dependabot cryptography 41.0.4

### DIFF
--- a/circleci/images/citusupgradetester/files/etc/requirements.txt
+++ b/circleci/images/citusupgradetester/files/etc/requirements.txt
@@ -4,6 +4,7 @@
 
 -i https://pypi.python.org/simple
 asgiref==3.4.1; python_version >= '3.6'
+black==23.9.1; python_version >= '3.8'
 blinker==1.4
 brotli==1.0.9
 certifi==2023.7.22; python_version >= '3.6'
@@ -28,8 +29,11 @@ ldap3==2.9.1
 markupsafe==2.1.3; python_version >= '3.7'
 -e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
 msgpack==1.0.6; python_version >= '3.8'
+mypy-extensions==1.0.0; python_version >= '3.5'
 packaging==23.1; python_version >= '3.7'
 passlib==1.7.4
+pathspec==0.11.2; python_version >= '3.7'
+platformdirs==3.10.0; python_version >= '3.7'
 pluggy==1.3.0; python_version >= '3.8'
 protobuf==3.18.3; python_version >= '3.5'
 psycopg==3.1.11; python_version >= '3.7'

--- a/circleci/images/citusupgradetester/files/etc/requirements.txt
+++ b/circleci/images/citusupgradetester/files/etc/requirements.txt
@@ -4,7 +4,6 @@
 
 -i https://pypi.python.org/simple
 asgiref==3.4.1; python_version >= '3.6'
-black==23.9.1; python_version >= '3.8'
 blinker==1.4
 brotli==1.0.9
 certifi==2023.7.22; python_version >= '3.6'
@@ -29,11 +28,8 @@ ldap3==2.9.1
 markupsafe==2.1.3; python_version >= '3.7'
 -e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
 msgpack==1.0.6; python_version >= '3.8'
-mypy-extensions==1.0.0; python_version >= '3.5'
 packaging==23.1; python_version >= '3.7'
 passlib==1.7.4
-pathspec==0.11.2; python_version >= '3.7'
-platformdirs==3.10.0; python_version >= '3.7'
 pluggy==1.3.0; python_version >= '3.8'
 protobuf==3.18.3; python_version >= '3.5'
 psycopg==3.1.11; python_version >= '3.7'

--- a/circleci/images/citusupgradetester/files/etc/requirements.txt
+++ b/circleci/images/citusupgradetester/files/etc/requirements.txt
@@ -3,55 +3,54 @@
 # need for pipenv/pyenv in this image
 
 -i https://pypi.python.org/simple
-asgiref==3.4.1
+asgiref==3.4.1; python_version >= '3.6'
 blinker==1.4
 brotli==1.0.9
-certifi==2023.7.22
+certifi==2023.7.22; python_version >= '3.6'
 cffi==1.15.1
-click==8.0.4
+click==8.0.4; python_version >= '3.6'
 construct==2.9.45
-cryptography==41.0.3
+cryptography==41.0.4; python_version >= '3.7'
 docopt==0.6.2
 exceptiongroup==1.1.3; python_version < '3.11'
-execnet==2.0.2
-filelock==3.12.2
-flask==2.0.3
-h11==0.12.0
-h2==4.1.0
-hpack==4.0.0
-hyperframe==6.0.1
-iniconfig==2.0.0
-itsdangerous==2.1.2
-jinja2==3.1.2
+execnet==2.0.2; python_version >= '3.7'
+filelock==3.12.4; python_version >= '3.8'
+flask==2.0.3; python_version >= '3.6'
+h11==0.12.0; python_version >= '3.6'
+h2==4.1.0; python_full_version >= '3.6.1'
+hpack==4.0.0; python_full_version >= '3.6.1'
+hyperframe==6.0.1; python_full_version >= '3.6.1'
+iniconfig==2.0.0; python_version >= '3.7'
+itsdangerous==2.1.2; python_version >= '3.7'
+jinja2==3.1.2; python_version >= '3.7'
 kaitaistruct==0.9
 ldap3==2.9.1
-markupsafe==2.1.3
+markupsafe==2.1.3; python_version >= '3.7'
 -e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
-msgpack==1.0.5
-packaging==23.1
+msgpack==1.0.6; python_version >= '3.8'
+packaging==23.1; python_version >= '3.7'
 passlib==1.7.4
-pluggy==1.2.0
-protobuf==3.18.3
-psycopg==3.1.10
+pluggy==1.3.0; python_version >= '3.8'
+protobuf==3.18.3; python_version >= '3.5'
+psycopg==3.1.11; python_version >= '3.7'
 publicsuffix2==2.20191221
-pyasn1==0.5.0
+pyasn1==0.5.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 pycparser==2.21
-pyopenssl==23.2.0
-pyparsing==2.4.7
+pyopenssl==23.2.0; python_version >= '3.6'
+pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pyperclip==1.8.2
-pytest-asyncio==0.21.1
-pytest-repeat==0.9.1
-pytest-timeout==2.1.0
-pytest-xdist==3.3.1
-pytest==7.4.0
-pyyaml==6.0.1
-ruamel.yaml.clib==0.2.7; platform_python_implementation == 'CPython' and python_version < '3.10'
-ruamel.yaml==0.17.16
+pytest==7.4.2; python_version >= '3.7'
+pytest-asyncio==0.21.1; python_version >= '3.7'
+pytest-repeat==0.9.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+pytest-timeout==2.1.0; python_version >= '3.6'
+pytest-xdist==3.3.1; python_version >= '3.7'
+pyyaml==6.0.1; python_version >= '3.6'
+ruamel.yaml==0.17.16; python_version >= '3'
 sortedcontainers==2.4.0
 tomli==2.0.1; python_version < '3.11'
-tornado==6.3.3
-typing-extensions==4.7.1
+tornado==6.3.3; python_version >= '3.8'
+typing-extensions==4.8.0; python_version >= '3.8'
 urwid==2.1.2
-werkzeug==2.3.7
-wsproto==1.0.0
-zstandard==0.15.2
+werkzeug==2.3.7; python_version >= '3.8'
+wsproto==1.0.0; python_full_version >= '3.6.1'
+zstandard==0.15.2; python_version >= '3.5'

--- a/circleci/images/failtester/files/etc/requirements.txt
+++ b/circleci/images/failtester/files/etc/requirements.txt
@@ -4,6 +4,7 @@
 
 -i https://pypi.python.org/simple
 asgiref==3.4.1; python_version >= '3.6'
+black==23.9.1; python_version >= '3.8'
 blinker==1.4
 brotli==1.0.9
 certifi==2023.7.22; python_version >= '3.6'
@@ -28,8 +29,11 @@ ldap3==2.9.1
 markupsafe==2.1.3; python_version >= '3.7'
 -e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
 msgpack==1.0.6; python_version >= '3.8'
+mypy-extensions==1.0.0; python_version >= '3.5'
 packaging==23.1; python_version >= '3.7'
 passlib==1.7.4
+pathspec==0.11.2; python_version >= '3.7'
+platformdirs==3.10.0; python_version >= '3.7'
 pluggy==1.3.0; python_version >= '3.8'
 protobuf==3.18.3; python_version >= '3.5'
 psycopg==3.1.11; python_version >= '3.7'

--- a/circleci/images/failtester/files/etc/requirements.txt
+++ b/circleci/images/failtester/files/etc/requirements.txt
@@ -4,7 +4,6 @@
 
 -i https://pypi.python.org/simple
 asgiref==3.4.1; python_version >= '3.6'
-black==23.9.1; python_version >= '3.8'
 blinker==1.4
 brotli==1.0.9
 certifi==2023.7.22; python_version >= '3.6'
@@ -29,11 +28,8 @@ ldap3==2.9.1
 markupsafe==2.1.3; python_version >= '3.7'
 -e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
 msgpack==1.0.6; python_version >= '3.8'
-mypy-extensions==1.0.0; python_version >= '3.5'
 packaging==23.1; python_version >= '3.7'
 passlib==1.7.4
-pathspec==0.11.2; python_version >= '3.7'
-platformdirs==3.10.0; python_version >= '3.7'
 pluggy==1.3.0; python_version >= '3.8'
 protobuf==3.18.3; python_version >= '3.5'
 psycopg==3.1.11; python_version >= '3.7'

--- a/circleci/images/failtester/files/etc/requirements.txt
+++ b/circleci/images/failtester/files/etc/requirements.txt
@@ -3,55 +3,54 @@
 # need for pipenv/pyenv in this image
 
 -i https://pypi.python.org/simple
-asgiref==3.4.1
+asgiref==3.4.1; python_version >= '3.6'
 blinker==1.4
 brotli==1.0.9
-certifi==2023.7.22
+certifi==2023.7.22; python_version >= '3.6'
 cffi==1.15.1
-click==8.0.4
+click==8.0.4; python_version >= '3.6'
 construct==2.9.45
-cryptography==41.0.3
+cryptography==41.0.4; python_version >= '3.7'
 docopt==0.6.2
 exceptiongroup==1.1.3; python_version < '3.11'
-execnet==2.0.2
-filelock==3.12.2
-flask==2.0.3
-h11==0.12.0
-h2==4.1.0
-hpack==4.0.0
-hyperframe==6.0.1
-iniconfig==2.0.0
-itsdangerous==2.1.2
-jinja2==3.1.2
+execnet==2.0.2; python_version >= '3.7'
+filelock==3.12.4; python_version >= '3.8'
+flask==2.0.3; python_version >= '3.6'
+h11==0.12.0; python_version >= '3.6'
+h2==4.1.0; python_full_version >= '3.6.1'
+hpack==4.0.0; python_full_version >= '3.6.1'
+hyperframe==6.0.1; python_full_version >= '3.6.1'
+iniconfig==2.0.0; python_version >= '3.7'
+itsdangerous==2.1.2; python_version >= '3.7'
+jinja2==3.1.2; python_version >= '3.7'
 kaitaistruct==0.9
 ldap3==2.9.1
-markupsafe==2.1.3
+markupsafe==2.1.3; python_version >= '3.7'
 -e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
-msgpack==1.0.5
-packaging==23.1
+msgpack==1.0.6; python_version >= '3.8'
+packaging==23.1; python_version >= '3.7'
 passlib==1.7.4
-pluggy==1.2.0
-protobuf==3.18.3
-psycopg==3.1.10
+pluggy==1.3.0; python_version >= '3.8'
+protobuf==3.18.3; python_version >= '3.5'
+psycopg==3.1.11; python_version >= '3.7'
 publicsuffix2==2.20191221
-pyasn1==0.5.0
+pyasn1==0.5.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 pycparser==2.21
-pyopenssl==23.2.0
-pyparsing==2.4.7
+pyopenssl==23.2.0; python_version >= '3.6'
+pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pyperclip==1.8.2
-pytest-asyncio==0.21.1
-pytest-repeat==0.9.1
-pytest-timeout==2.1.0
-pytest-xdist==3.3.1
-pytest==7.4.0
-pyyaml==6.0.1
-ruamel.yaml.clib==0.2.7; platform_python_implementation == 'CPython' and python_version < '3.10'
-ruamel.yaml==0.17.16
+pytest==7.4.2; python_version >= '3.7'
+pytest-asyncio==0.21.1; python_version >= '3.7'
+pytest-repeat==0.9.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+pytest-timeout==2.1.0; python_version >= '3.6'
+pytest-xdist==3.3.1; python_version >= '3.7'
+pyyaml==6.0.1; python_version >= '3.6'
+ruamel.yaml==0.17.16; python_version >= '3'
 sortedcontainers==2.4.0
 tomli==2.0.1; python_version < '3.11'
-tornado==6.3.3
-typing-extensions==4.7.1
+tornado==6.3.3; python_version >= '3.8'
+typing-extensions==4.8.0; python_version >= '3.8'
 urwid==2.1.2
-werkzeug==2.3.7
-wsproto==1.0.0
-zstandard==0.15.2
+werkzeug==2.3.7; python_version >= '3.8'
+wsproto==1.0.0; python_full_version >= '3.6.1'
+zstandard==0.15.2; python_version >= '3.5'

--- a/circleci/images/pgupgradetester/files/etc/requirements.txt
+++ b/circleci/images/pgupgradetester/files/etc/requirements.txt
@@ -4,6 +4,7 @@
 
 -i https://pypi.python.org/simple
 asgiref==3.4.1; python_version >= '3.6'
+black==23.9.1; python_version >= '3.8'
 blinker==1.4
 brotli==1.0.9
 certifi==2023.7.22; python_version >= '3.6'
@@ -28,8 +29,11 @@ ldap3==2.9.1
 markupsafe==2.1.3; python_version >= '3.7'
 -e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
 msgpack==1.0.6; python_version >= '3.8'
+mypy-extensions==1.0.0; python_version >= '3.5'
 packaging==23.1; python_version >= '3.7'
 passlib==1.7.4
+pathspec==0.11.2; python_version >= '3.7'
+platformdirs==3.10.0; python_version >= '3.7'
 pluggy==1.3.0; python_version >= '3.8'
 protobuf==3.18.3; python_version >= '3.5'
 psycopg==3.1.11; python_version >= '3.7'

--- a/circleci/images/pgupgradetester/files/etc/requirements.txt
+++ b/circleci/images/pgupgradetester/files/etc/requirements.txt
@@ -4,7 +4,6 @@
 
 -i https://pypi.python.org/simple
 asgiref==3.4.1; python_version >= '3.6'
-black==23.9.1; python_version >= '3.8'
 blinker==1.4
 brotli==1.0.9
 certifi==2023.7.22; python_version >= '3.6'
@@ -29,11 +28,8 @@ ldap3==2.9.1
 markupsafe==2.1.3; python_version >= '3.7'
 -e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
 msgpack==1.0.6; python_version >= '3.8'
-mypy-extensions==1.0.0; python_version >= '3.5'
 packaging==23.1; python_version >= '3.7'
 passlib==1.7.4
-pathspec==0.11.2; python_version >= '3.7'
-platformdirs==3.10.0; python_version >= '3.7'
 pluggy==1.3.0; python_version >= '3.8'
 protobuf==3.18.3; python_version >= '3.5'
 psycopg==3.1.11; python_version >= '3.7'

--- a/circleci/images/pgupgradetester/files/etc/requirements.txt
+++ b/circleci/images/pgupgradetester/files/etc/requirements.txt
@@ -3,55 +3,54 @@
 # need for pipenv/pyenv in this image
 
 -i https://pypi.python.org/simple
-asgiref==3.4.1
+asgiref==3.4.1; python_version >= '3.6'
 blinker==1.4
 brotli==1.0.9
-certifi==2023.7.22
+certifi==2023.7.22; python_version >= '3.6'
 cffi==1.15.1
-click==8.0.4
+click==8.0.4; python_version >= '3.6'
 construct==2.9.45
-cryptography==41.0.3
+cryptography==41.0.4; python_version >= '3.7'
 docopt==0.6.2
 exceptiongroup==1.1.3; python_version < '3.11'
-execnet==2.0.2
-filelock==3.12.2
-flask==2.0.3
-h11==0.12.0
-h2==4.1.0
-hpack==4.0.0
-hyperframe==6.0.1
-iniconfig==2.0.0
-itsdangerous==2.1.2
-jinja2==3.1.2
+execnet==2.0.2; python_version >= '3.7'
+filelock==3.12.4; python_version >= '3.8'
+flask==2.0.3; python_version >= '3.6'
+h11==0.12.0; python_version >= '3.6'
+h2==4.1.0; python_full_version >= '3.6.1'
+hpack==4.0.0; python_full_version >= '3.6.1'
+hyperframe==6.0.1; python_full_version >= '3.6.1'
+iniconfig==2.0.0; python_version >= '3.7'
+itsdangerous==2.1.2; python_version >= '3.7'
+jinja2==3.1.2; python_version >= '3.7'
 kaitaistruct==0.9
 ldap3==2.9.1
-markupsafe==2.1.3
+markupsafe==2.1.3; python_version >= '3.7'
 -e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
-msgpack==1.0.5
-packaging==23.1
+msgpack==1.0.6; python_version >= '3.8'
+packaging==23.1; python_version >= '3.7'
 passlib==1.7.4
-pluggy==1.2.0
-protobuf==3.18.3
-psycopg==3.1.10
+pluggy==1.3.0; python_version >= '3.8'
+protobuf==3.18.3; python_version >= '3.5'
+psycopg==3.1.11; python_version >= '3.7'
 publicsuffix2==2.20191221
-pyasn1==0.5.0
+pyasn1==0.5.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 pycparser==2.21
-pyopenssl==23.2.0
-pyparsing==2.4.7
+pyopenssl==23.2.0; python_version >= '3.6'
+pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pyperclip==1.8.2
-pytest-asyncio==0.21.1
-pytest-repeat==0.9.1
-pytest-timeout==2.1.0
-pytest-xdist==3.3.1
-pytest==7.4.0
-pyyaml==6.0.1
-ruamel.yaml.clib==0.2.7; platform_python_implementation == 'CPython' and python_version < '3.10'
-ruamel.yaml==0.17.16
+pytest==7.4.2; python_version >= '3.7'
+pytest-asyncio==0.21.1; python_version >= '3.7'
+pytest-repeat==0.9.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+pytest-timeout==2.1.0; python_version >= '3.6'
+pytest-xdist==3.3.1; python_version >= '3.7'
+pyyaml==6.0.1; python_version >= '3.6'
+ruamel.yaml==0.17.16; python_version >= '3'
 sortedcontainers==2.4.0
 tomli==2.0.1; python_version < '3.11'
-tornado==6.3.3
-typing-extensions==4.7.1
+tornado==6.3.3; python_version >= '3.8'
+typing-extensions==4.8.0; python_version >= '3.8'
 urwid==2.1.2
-werkzeug==2.3.7
-wsproto==1.0.0
-zstandard==0.15.2
+werkzeug==2.3.7; python_version >= '3.8'
+wsproto==1.0.0; python_full_version >= '3.6.1'
+zstandard==0.15.2; python_version >= '3.5'

--- a/circleci/images/stylechecker/files/etc/requirements.txt
+++ b/circleci/images/stylechecker/files/etc/requirements.txt
@@ -1,68 +1,56 @@
 # generated from Citus's Pipfile.lock (in src/test/regress) as of #7111
-# using `pipenv requirements --dev > requirements.txt`, so as to avoid the
+# using `pipenv requirements > requirements.txt`, so as to avoid the
 # need for pipenv/pyenv in this image
 
 -i https://pypi.python.org/simple
-attrs==23.1.0; python_version >= '3.7'
-black==23.7.0
-click==8.0.4; python_version >= '3.6'
-flake8==6.1.0
-flake8-bugbear==23.7.10
-isort==5.12.0
-mccabe==0.7.0; python_version >= '3.6'
-mypy-extensions==1.0.0 ; python_version >= '3.5'
-packaging==23.1; python_version >= '3.7'
-pathspec==0.11.2; python_version >= '3.7'
-platformdirs==3.10.0; python_version >= '3.7'
-pycodestyle==2.11.0; python_version >= '3.6'
-pyflakes==3.1.0; python_version >= '3.6'
-tomli==2.0.1; python_version < '3.11'
-typing-extensions==4.7.1; python_version >= '3.7'
-asgiref==3.4.1
+asgiref==3.4.1; python_version >= '3.6'
 blinker==1.4
 brotli==1.0.9
-certifi==2023.7.22
+certifi==2023.7.22; python_version >= '3.6'
 cffi==1.15.1
+click==8.0.4; python_version >= '3.6'
 construct==2.9.45
-cryptography==41.0.3
+cryptography==41.0.4; python_version >= '3.7'
 docopt==0.6.2
 exceptiongroup==1.1.3; python_version < '3.11'
-execnet==2.0.2
-filelock==3.12.2
-flask==2.0.3
-h11==0.12.0
-h2==4.1.0
-hpack==4.0.0
-hyperframe==6.0.1
-iniconfig==2.0.0
-itsdangerous==2.1.2
-jinja2==3.1.2
+execnet==2.0.2; python_version >= '3.7'
+filelock==3.12.4; python_version >= '3.8'
+flask==2.0.3; python_version >= '3.6'
+h11==0.12.0; python_version >= '3.6'
+h2==4.1.0; python_full_version >= '3.6.1'
+hpack==4.0.0; python_full_version >= '3.6.1'
+hyperframe==6.0.1; python_full_version >= '3.6.1'
+iniconfig==2.0.0; python_version >= '3.7'
+itsdangerous==2.1.2; python_version >= '3.7'
+jinja2==3.1.2; python_version >= '3.7'
 kaitaistruct==0.9
 ldap3==2.9.1
-markupsafe==2.1.3
+markupsafe==2.1.3; python_version >= '3.7'
 -e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
-msgpack==1.0.5
+msgpack==1.0.6; python_version >= '3.8'
+packaging==23.1; python_version >= '3.7'
 passlib==1.7.4
-pluggy==1.2.0
-protobuf==3.18.3
-psycopg==3.1.10
+pluggy==1.3.0; python_version >= '3.8'
+protobuf==3.18.3; python_version >= '3.5'
+psycopg==3.1.11; python_version >= '3.7'
 publicsuffix2==2.20191221
-pyasn1==0.5.0
+pyasn1==0.5.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 pycparser==2.21
-pyopenssl==23.2.0
-pyparsing==2.4.7
+pyopenssl==23.2.0; python_version >= '3.6'
+pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
 pyperclip==1.8.2
-pytest==7.4.0
-pytest-asyncio==0.21.1
-pytest-repeat==0.9.1
-pytest-timeout==2.1.0
-pytest-xdist==3.3.1
-pyyaml==6.0.1
-ruamel.yaml.clib==0.2.7; platform_python_implementation == 'CPython' and python_version < '3.10'
-ruamel.yaml==0.17.16
+pytest==7.4.2; python_version >= '3.7'
+pytest-asyncio==0.21.1; python_version >= '3.7'
+pytest-repeat==0.9.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+pytest-timeout==2.1.0; python_version >= '3.6'
+pytest-xdist==3.3.1; python_version >= '3.7'
+pyyaml==6.0.1; python_version >= '3.6'
+ruamel.yaml==0.17.16; python_version >= '3'
 sortedcontainers==2.4.0
-tornado==6.3.3
+tomli==2.0.1; python_version < '3.11'
+tornado==6.3.3; python_version >= '3.8'
+typing-extensions==4.8.0; python_version >= '3.8'
 urwid==2.1.2
-werkzeug==2.3.7
-wsproto==1.0.0
-zstandard==0.15.2
+werkzeug==2.3.7; python_version >= '3.8'
+wsproto==1.0.0; python_full_version >= '3.6.1'
+zstandard==0.15.2; python_version >= '3.5'

--- a/circleci/images/stylechecker/files/etc/requirements.txt
+++ b/circleci/images/stylechecker/files/etc/requirements.txt
@@ -4,6 +4,7 @@
 
 -i https://pypi.python.org/simple
 asgiref==3.4.1; python_version >= '3.6'
+black==23.9.1; python_version >= '3.8'
 blinker==1.4
 brotli==1.0.9
 certifi==2023.7.22; python_version >= '3.6'
@@ -28,8 +29,11 @@ ldap3==2.9.1
 markupsafe==2.1.3; python_version >= '3.7'
 -e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
 msgpack==1.0.6; python_version >= '3.8'
+mypy-extensions==1.0.0; python_version >= '3.5'
 packaging==23.1; python_version >= '3.7'
 passlib==1.7.4
+pathspec==0.11.2; python_version >= '3.7'
+platformdirs==3.10.0; python_version >= '3.7'
 pluggy==1.3.0; python_version >= '3.8'
 protobuf==3.18.3; python_version >= '3.5'
 psycopg==3.1.11; python_version >= '3.7'

--- a/circleci/images/stylechecker/files/etc/requirements.txt
+++ b/circleci/images/stylechecker/files/etc/requirements.txt
@@ -1,15 +1,28 @@
 # generated from Citus's Pipfile.lock (in src/test/regress) as of #7111
-# using `pipenv requirements > requirements.txt`, so as to avoid the
+# using `pipenv requirements --dev > requirements.txt`, so as to avoid the
 # need for pipenv/pyenv in this image
 
 -i https://pypi.python.org/simple
-asgiref==3.4.1; python_version >= '3.6'
+attrs==23.1.0; python_version >= '3.7'
 black==23.9.1; python_version >= '3.8'
+click==8.0.4; python_version >= '3.6'
+flake8==6.1.0; python_full_version >= '3.8.1'
+flake8-bugbear==23.9.16; python_full_version >= '3.8.1'
+isort==5.12.0; python_full_version >= '3.8.0'
+mccabe==0.7.0; python_version >= '3.6'
+mypy-extensions==1.0.0; python_version >= '3.5'
+packaging==23.1; python_version >= '3.7'
+pathspec==0.11.2; python_version >= '3.7'
+platformdirs==3.10.0; python_version >= '3.7'
+pycodestyle==2.11.0; python_version >= '3.8'
+pyflakes==3.1.0; python_version >= '3.8'
+tomli==2.0.1; python_version < '3.11'
+typing-extensions==4.8.0; python_version >= '3.8'
+asgiref==3.4.1; python_version >= '3.6'
 blinker==1.4
 brotli==1.0.9
 certifi==2023.7.22; python_version >= '3.6'
 cffi==1.15.1
-click==8.0.4; python_version >= '3.6'
 construct==2.9.45
 cryptography==41.0.4; python_version >= '3.7'
 docopt==0.6.2
@@ -29,11 +42,7 @@ ldap3==2.9.1
 markupsafe==2.1.3; python_version >= '3.7'
 -e git+https://github.com/citusdata/mitmproxy.git@2fd18ef051b987925a36337ab1d61aa674353b44#egg=mitmproxy
 msgpack==1.0.6; python_version >= '3.8'
-mypy-extensions==1.0.0; python_version >= '3.5'
-packaging==23.1; python_version >= '3.7'
 passlib==1.7.4
-pathspec==0.11.2; python_version >= '3.7'
-platformdirs==3.10.0; python_version >= '3.7'
 pluggy==1.3.0; python_version >= '3.8'
 protobuf==3.18.3; python_version >= '3.5'
 psycopg==3.1.11; python_version >= '3.7'
@@ -51,9 +60,7 @@ pytest-xdist==3.3.1; python_version >= '3.7'
 pyyaml==6.0.1; python_version >= '3.6'
 ruamel.yaml==0.17.16; python_version >= '3'
 sortedcontainers==2.4.0
-tomli==2.0.1; python_version < '3.11'
 tornado==6.3.3; python_version >= '3.8'
-typing-extensions==4.8.0; python_version >= '3.8'
 urwid==2.1.2
 werkzeug==2.3.7; python_version >= '3.8'
 wsproto==1.0.0; python_full_version >= '3.6.1'


### PR DESCRIPTION
Mostly a new export of `pipenv requirements` exported from https://github.com/citusdata/citus/pull/7231

Once this PR lands we can merge the Citus PR after updating the image tags to the newly built images from `master` here.