### PR TITLE
Wal2json pg16 package available

### DIFF
--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -145,11 +145,7 @@ RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /e
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}-dbgsym=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \
-# wal2json not available yet for PG16
- && if [ "$PG_MAJOR" != "16" ]; \
-    then \
-        apt-get install -y --no-install-recommends --allow-downgrades postgresql-${PG_MAJOR}-wal2json; \
-    fi \
+    postgresql-${PG_MAJOR}-wal2json \
 # clear apt cache
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Wal2json PG16 package is now available.

Sister PR https://github.com/citusdata/citus/pull/7361