### PR TITLE
Move CI images to GHCR

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -38,11 +38,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USER_NAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
 
       # If current branch is not master,build and publish dev image
       - name: Build & Push all dev images
@@ -66,11 +67,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USER_NAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
 
       # If current branch is not master,build and publish dev image
       - name: Build & Push all dev images
@@ -90,11 +92,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
+      - name: 'Login to GitHub Container Registry'
+        uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USER_NAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          registry: ghcr.io
+          username: ${{github.actor}}
+          password: ${{secrets.GITHUB_TOKEN}}
 
       - name: Build & Push all live images
         run: |

--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -42,8 +42,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{github.actor}}
-          password: ${{secrets.GITHUB_TOKEN}}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # If current branch is not master,build and publish dev image
       - name: Build & Push all dev images
@@ -71,8 +71,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{github.actor}}
-          password: ${{secrets.GITHUB_TOKEN}}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # If current branch is not master,build and publish dev image
       - name: Build & Push all dev images
@@ -96,8 +96,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
-          username: ${{github.actor}}
-          password: ${{secrets.GITHUB_TOKEN}}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & Push all live images
         run: |

--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -1,5 +1,5 @@
 # config variable
-DOCKER_REPO ?= citus
+DOCKER_REPO ?= ghcr.io/citusdata
 SHA_SUFFIX := $(shell git rev-parse --short HEAD)
 
 # auto generated variables

--- a/circleci/images/citusupgradetester/Dockerfile
+++ b/circleci/images/citusupgradetester/Dockerfile
@@ -68,6 +68,7 @@ pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep 
 apt-get install -y --no-install-recommends --allow-downgrades \
     libpq-dev=${pgdg_version} \
     libpq5=${pgdg_version} \
+    postgresql-${PG_MAJOR}=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}-dbgsym=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \

--- a/circleci/images/citusupgradetester/Dockerfile
+++ b/circleci/images/citusupgradetester/Dockerfile
@@ -6,6 +6,7 @@ RUN useradd -ms /bin/bash circleci
 
 RUN <<'EOF'
 # install dependencies
+set -eux
 apt-get update
 
 apt-get install -y --no-install-recommends \
@@ -54,6 +55,7 @@ ENV PG_MAJOR=$PG_MAJOR
 
 RUN <<'EOF'
 # install postgres ecosystem for pg version: $PG_VERSION
+set -eux
 
 # install key and repositories
 curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
@@ -88,6 +90,7 @@ FROM base AS builder
 
 RUN <<'EOF'
 # install dependencies
+set -eux
 apt update
 
 apt install -y \

--- a/circleci/images/citusupgradetester/Dockerfile
+++ b/circleci/images/citusupgradetester/Dockerfile
@@ -4,9 +4,11 @@ FROM python:3.9.7-slim-bullseye AS base
 # add unpriviliged user for tests
 RUN useradd -ms /bin/bash circleci
 
-RUN apt-get update \
+RUN <<'EOF'
 # install dependencies
- && apt-get install -y --no-install-recommends \
+apt-get update
+
+apt-get install -y --no-install-recommends \
     apt-transport-https \
     autoconf \
     build-essential \
@@ -34,7 +36,8 @@ RUN apt-get update \
     perl \
 
 # clear apt cache
- && rm -rf /var/lib/apt/lists/*
+rm -rf /var/lib/apt/lists/*
+EOF
 
 # make special locales available
 COPY locale.gen /etc/locale.gen
@@ -43,28 +46,35 @@ RUN locale-gen
 # Add codeclimate
 RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter && chmod +x /usr/local/bin/cc-test-reporter
 
-# add postgres signing key
-RUN curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
-
 ARG PG_VERSION
 ARG PG_MAJOR
 ENV PG_VERSION=$PG_VERSION
 ENV PG_MAJOR=$PG_MAJOR
 
-# add postgres repository
-RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /etc/apt/sources.list.d/postgresql.list \
- && echo "deb https://apt-archive.postgresql.org/pub/repos/apt bullseye-pgdg-archive main" >> /etc/apt/sources.list.d/postgresql.list \
- && apt-get update \
+
+RUN <<'EOF'
+# install postgres ecosystem for pg version: $PG_VERSION
+
+# install key and repositories
+curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
+echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /etc/apt/sources.list.d/postgresql.list
+echo "deb https://apt-archive.postgresql.org/pub/repos/apt bullseye-pgdg-archive main" >> /etc/apt/sources.list.d/postgresql.list
+
+apt-get update
+
 # infer the pgdgversion of postgres based on the $PG_VERSION
- && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ) \
- && apt-get install -y --no-install-recommends --allow-downgrades \
+pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 )
+
+apt-get install -y --no-install-recommends --allow-downgrades \
     libpq-dev=${pgdg_version} \
     libpq5=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}-dbgsym=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \
+
 # clear apt cache
- && rm -rf /var/lib/apt/lists/*
+rm -rf /var/lib/apt/lists/*
+EOF
 
 # add postgress to the path
 ENV PATH=/usr/lib/postgresql/$PG_MAJOR/bin/:$PATH
@@ -75,11 +85,17 @@ RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgres
 ##############################################################################
 FROM base AS builder
 
-RUN apt update \
- && apt install -y \
+RUN <<'EOF'
+# install dependencies
+apt update
+
+apt install -y \
     git \
     libkrb5-dev \
- && rm -rf /var/lib/apt/lists/*
+
+# clear apt cache
+rm -rf /var/lib/apt/lists/*
+EOF
 
 ARG CITUS_VERSIONS
 ENV CITUS_VERSIONS=$CITUS_VERSIONS
@@ -97,8 +113,6 @@ RUN chown -R circleci /usr/lib/postgresql/ /usr/include/postgresql/ /usr/share/p
 
 COPY ./files/etc/requirements.txt /tmp/etc/
 RUN pip3 install -Ir /tmp/etc/requirements.txt
-
-WORKDIR /home/circleci
 
 ARG CITUS_VERSIONS
 ENV CITUS_VERSIONS=$CITUS_VERSIONS

--- a/circleci/images/extbuilder/Dockerfile
+++ b/circleci/images/extbuilder/Dockerfile
@@ -3,9 +3,11 @@ FROM buildpack-deps:bullseye
 # add unpriviliged user for tests
 RUN useradd -ms /bin/bash circleci
 
-RUN apt-get update \
+RUN <<'EOF'
 # install dependencies
- && apt-get install -y --no-install-recommends \
+apt-get update
+
+apt-get install -y --no-install-recommends \
     apt-transport-https \
     autoconf \
     build-essential \
@@ -29,31 +31,39 @@ RUN apt-get update \
     locales \
     make \
     perl \
-# clear apt cache
- && rm -rf /var/lib/apt/lists/*
 
-# add postgres signing key
-RUN curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
+# clear apt cache
+rm -rf /var/lib/apt/lists/*
+EOF
 
 ARG PG_VERSION
 ARG PG_MAJOR
 ENV PG_VERSION=$PG_VERSION
 ENV PG_MAJOR=$PG_MAJOR
 
-# add postgres repository
-RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /etc/apt/sources.list.d/postgresql.list \
- && echo "deb https://apt-archive.postgresql.org/pub/repos/apt bullseye-pgdg-archive main" >> /etc/apt/sources.list.d/postgresql.list \
- && apt-get update \
+RUN <<'EOF'
+# install postgres ecosystem for pg version: $PG_VERSION
+
+# install key and repositories
+curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
+echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /etc/apt/sources.list.d/postgresql.list
+echo "deb https://apt-archive.postgresql.org/pub/repos/apt bullseye-pgdg-archive main" >> /etc/apt/sources.list.d/postgresql.list
+
+apt-get update
+
 # infer the pgdgversion of postgres based on the $PG_VERSION
- && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ) \
- && apt-get install -y --no-install-recommends --allow-downgrades \
+pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 )
+
+apt-get install -y --no-install-recommends --allow-downgrades \
     libpq-dev=${pgdg_version} \
     libpq5=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}-dbgsym=${pgdg_version} \
-    postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \
+    postgresql-server-dev-${PG_MAJOR}=${pgdg_version}
+
 # clear apt cache
- && rm -rf /var/lib/apt/lists/*
+rm -rf /var/lib/apt/lists/*
+EOF
 
 USER circleci
 WORKDIR /home/circleci

--- a/circleci/images/extbuilder/Dockerfile
+++ b/circleci/images/extbuilder/Dockerfile
@@ -57,6 +57,7 @@ pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep 
 apt-get install -y --no-install-recommends --allow-downgrades \
     libpq-dev=${pgdg_version} \
     libpq5=${pgdg_version} \
+    postgresql-${PG_MAJOR}=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}-dbgsym=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version}

--- a/circleci/images/extbuilder/Dockerfile
+++ b/circleci/images/extbuilder/Dockerfile
@@ -5,6 +5,7 @@ RUN useradd -ms /bin/bash circleci
 
 RUN <<'EOF'
 # install dependencies
+set -eux
 apt-get update
 
 apt-get install -y --no-install-recommends \
@@ -43,6 +44,7 @@ ENV PG_MAJOR=$PG_MAJOR
 
 RUN <<'EOF'
 # install postgres ecosystem for pg version: $PG_VERSION
+set -eux
 
 # install key and repositories
 curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -156,6 +156,7 @@ apt-get install -y --no-install-recommends --allow-downgrades \
     libdbd-pg-perl \
     libpq-dev=${pgdg_version} \
     libpq5=${pgdg_version} \
+    postgresql-${PG_MAJOR}=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}-dbgsym=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -2,9 +2,11 @@
 # we use this builder to build the isolation tester from a specific version
 FROM buildpack-deps:bullseye AS dev-tools-builder
 
-RUN apt-get update \
+RUN <<'EOF'
 # install dependencies
- && apt-get install -y --no-install-recommends \
+apt-get update
+
+apt-get install -y --no-install-recommends \
     apt-transport-https \
     autoconf \
     build-essential \
@@ -28,8 +30,10 @@ RUN apt-get update \
     locales \
     make \
     perl \
+
 # clear apt cache
- && rm -rf /var/lib/apt/lists/*
+rm -rf /var/lib/apt/lists/*
+EOF
 
 ARG PG_VERSION
 ARG PG_VERSION_CLEAN
@@ -43,11 +47,13 @@ RUN tar jxf "postgresql-${PG_VERSION_CLEAN}.tar.bz2"
 # apply optional patches that might be required for a successful testsuite
 WORKDIR /build/postgresql-${PG_VERSION_CLEAN}/
 COPY patches/ patches/
-SHELL ["/bin/bash", "-c"]
-RUN if [ -d "patches/${PG_VERSION_CLEAN}/" ]; \
-    then \
-        git apply patches/${PG_VERSION_CLEAN}/*.patch; \
-    fi;
+RUN <<'EOF'
+# apply postgres patches
+if [ -d "patches/${PG_VERSION_CLEAN}/" ];
+then
+    git apply patches/${PG_VERSION_CLEAN}/*.patch;
+fi;
+EOF
 
 WORKDIR /build/postgresql-${PG_VERSION_CLEAN}/build
 RUN ../configure --prefix /usr/lib/postgresql/${PG_MAJOR}/
@@ -63,9 +69,9 @@ ARG PG_VERSION_CLEAN
 ARG PG_MAJOR
 
 COPY --from=dev-tools-builder \
-	/build/postgresql-${PG_VERSION_CLEAN}/build/src/test/isolation/pg_isolation_regress \
-	/build/postgresql-${PG_VERSION_CLEAN}/build/src/test/isolation/isolationtester \
-	build/postgresql-${PG_MAJOR}/build/src/test/isolation/
+  /build/postgresql-${PG_VERSION_CLEAN}/build/src/test/isolation/pg_isolation_regress \
+  /build/postgresql-${PG_VERSION_CLEAN}/build/src/test/isolation/isolationtester \
+  build/postgresql-${PG_MAJOR}/build/src/test/isolation/
 
 # copy regress files in multiple layers as we only need a few
 COPY --from=dev-tools-builder /build/postgresql-${PG_VERSION_CLEAN}/build/src/test/regress/regress.so usr/lib/postgresql/${PG_MAJOR}/lib/
@@ -77,9 +83,11 @@ FROM buildpack-deps:bullseye
 # add unpriviliged user for tests
 RUN useradd -ms /bin/bash circleci
 
-RUN apt-get update \
+RUN <<'EOF'
 # install dependencies
- && apt-get install -y --no-install-recommends \
+apt-get update
+
+apt-get install -y --no-install-recommends \
     apt-transport-https \
     autoconf \
     build-essential \
@@ -106,8 +114,10 @@ RUN apt-get update \
     locales \
     make \
     perl \
+
 # clear apt cache
- && rm -rf /var/lib/apt/lists/*
+rm -rf /var/lib/apt/lists/*
+EOF
 
 # install rust
 RUN curl --proto '=https' --tlsv1.2 --silent --show-error https://sh.rustup.rs | sh -s -- -y
@@ -123,21 +133,25 @@ RUN locale-gen
 # Add codeclimate
 RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter && chmod +x /usr/local/bin/cc-test-reporter
 
-# add postgres signing key
-RUN curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
-
 ARG PG_VERSION
 ARG PG_MAJOR
 ENV PG_VERSION=$PG_VERSION
 ENV PG_MAJOR=$PG_MAJOR
 
-# add postgres repository
-RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /etc/apt/sources.list.d/postgresql.list \
- && echo "deb https://apt-archive.postgresql.org/pub/repos/apt bullseye-pgdg-archive main" >> /etc/apt/sources.list.d/postgresql.list \
- && apt-get update \
+RUN <<'EOF'
+# install postgres ecosystem for pg version: $PG_VERSION
+
+# install key and repositories
+curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
+echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /etc/apt/sources.list.d/postgresql.list
+echo "deb https://apt-archive.postgresql.org/pub/repos/apt bullseye-pgdg-archive main" >> /etc/apt/sources.list.d/postgresql.list
+
+apt-get update
+
 # infer the pgdgversion of postgres based on the $PG_VERSION
- && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ) \
- && apt-get install -y --no-install-recommends --allow-downgrades \
+pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 )
+
+apt-get install -y --no-install-recommends --allow-downgrades \
     libdbi-perl \
     libdbd-pg-perl \
     libpq-dev=${pgdg_version} \
@@ -146,8 +160,10 @@ RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /e
     postgresql-${PG_MAJOR}-dbgsym=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}-wal2json \
-# clear apt cache
- && rm -rf /var/lib/apt/lists/*
+
+    # clear apt cache
+rm -rf /var/lib/apt/lists/*
+EOF
 
 # add postgress to the path
 ENV PATH=/usr/lib/postgresql/$PG_MAJOR/bin/:$PATH

--- a/circleci/images/exttester/Dockerfile
+++ b/circleci/images/exttester/Dockerfile
@@ -4,6 +4,8 @@ FROM buildpack-deps:bullseye AS dev-tools-builder
 
 RUN <<'EOF'
 # install dependencies
+set -eux
+
 apt-get update
 
 apt-get install -y --no-install-recommends \
@@ -49,6 +51,8 @@ WORKDIR /build/postgresql-${PG_VERSION_CLEAN}/
 COPY patches/ patches/
 RUN <<'EOF'
 # apply postgres patches
+
+set -eux
 if [ -d "patches/${PG_VERSION_CLEAN}/" ];
 then
     git apply patches/${PG_VERSION_CLEAN}/*.patch;
@@ -85,6 +89,8 @@ RUN useradd -ms /bin/bash circleci
 
 RUN <<'EOF'
 # install dependencies
+set -eux
+
 apt-get update
 
 apt-get install -y --no-install-recommends \
@@ -140,6 +146,7 @@ ENV PG_MAJOR=$PG_MAJOR
 
 RUN <<'EOF'
 # install postgres ecosystem for pg version: $PG_VERSION
+set -eux
 
 # install key and repositories
 curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -

--- a/circleci/images/failtester/Dockerfile
+++ b/circleci/images/failtester/Dockerfile
@@ -4,9 +4,11 @@ FROM python:3.9.7-slim-bullseye
 # add unpriviliged user for tests
 RUN useradd -ms /bin/bash circleci
 
-RUN apt-get update \
+RUN <<'EOF'
 # install dependencies
- && apt-get install -y --no-install-recommends \
+apt-get update
+
+apt-get install -y --no-install-recommends \
     apt-transport-https \
     autoconf \
     build-essential \
@@ -34,8 +36,10 @@ RUN apt-get update \
     make \
     net-tools \
     perl \
+
 # clear apt cache
- && rm -rf /var/lib/apt/lists/*
+rm -rf /var/lib/apt/lists/*
+EOF
 
 # make special locales available
 COPY locale.gen /etc/locale.gen
@@ -44,28 +48,34 @@ RUN locale-gen
 # Add codeclimate
 RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter && chmod +x /usr/local/bin/cc-test-reporter
 
-# add postgres signing key
-RUN curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
-
 ARG PG_VERSION
 ARG PG_MAJOR
 ENV PG_VERSION=$PG_VERSION
 ENV PG_MAJOR=$PG_MAJOR
 
-# add postgres repository
-RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /etc/apt/sources.list.d/postgresql.list \
- && echo "deb https://apt-archive.postgresql.org/pub/repos/apt bullseye-pgdg-archive main" >> /etc/apt/sources.list.d/postgresql.list \
- && apt-get update \
+RUN <<'EOF'
+# install postgres ecosystem for pg version: $PG_VERSION
+
+# install key and repositories
+curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
+echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /etc/apt/sources.list.d/postgresql.list
+echo "deb https://apt-archive.postgresql.org/pub/repos/apt bullseye-pgdg-archive main" >> /etc/apt/sources.list.d/postgresql.list
+
+apt-get update
+
 # infer the pgdgversion of postgres based on the $PG_VERSION
- && pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ) \
- && apt-get install -y --no-install-recommends --allow-downgrades \
+pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 )
+
+apt-get install -y --no-install-recommends --allow-downgrades \
     libpq-dev=${pgdg_version} \
     libpq5=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}-dbgsym=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \
+
 # clear apt cache
- && rm -rf /var/lib/apt/lists/*
+rm -rf /var/lib/apt/lists/*
+EOF
 
 # add postgress to the path
 ENV PATH=/usr/lib/postgresql/$PG_MAJOR/bin/:$PATH

--- a/circleci/images/failtester/Dockerfile
+++ b/circleci/images/failtester/Dockerfile
@@ -69,6 +69,7 @@ pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep 
 apt-get install -y --no-install-recommends --allow-downgrades \
     libpq-dev=${pgdg_version} \
     libpq5=${pgdg_version} \
+    postgresql-${PG_MAJOR}=${pgdg_version} \
     postgresql-client-${PG_MAJOR}=${pgdg_version} \
     postgresql-${PG_MAJOR}-dbgsym=${pgdg_version} \
     postgresql-server-dev-${PG_MAJOR}=${pgdg_version} \

--- a/circleci/images/pgupgradetester/Dockerfile
+++ b/circleci/images/pgupgradetester/Dockerfile
@@ -65,6 +65,7 @@ pkgs=();
 for PG_VERSION in $PG_VERSIONS; do
     PG_MAJOR=$(echo ${PG_VERSION} | awk -F'[^0-9]*' '/[0-9]/ { print $1 }')
     pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 )
+    pkgs+=("postgresql-${PG_MAJOR}=${pgdg_version}")
     pkgs+=("postgresql-client-${PG_MAJOR}=${pgdg_version}")
     pkgs+=("postgresql-${PG_MAJOR}-dbgsym=${pgdg_version}")
     pkgs+=("postgresql-server-dev-${PG_MAJOR}=${pgdg_version}")

--- a/circleci/images/pgupgradetester/Dockerfile
+++ b/circleci/images/pgupgradetester/Dockerfile
@@ -4,9 +4,11 @@ FROM python:3.9.7-slim-bullseye
 # add unpriviliged user for tests
 RUN useradd -ms /bin/bash circleci
 
-RUN apt-get update \
+RUN <<'EOF'
 # install dependencies
- && apt-get install -y --no-install-recommends \
+apt-get update
+
+apt-get install -y --no-install-recommends \
     apt-transport-https \
     autoconf \
     build-essential \
@@ -31,14 +33,13 @@ RUN apt-get update \
     libzstd1 \
     make \
     perl \
+
 # clear apt cache
- && rm -rf /var/lib/apt/lists/*
+rm -rf /var/lib/apt/lists/*
+EOF
 
 # Add codeclimate
 RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /usr/local/bin/cc-test-reporter && chmod +x /usr/local/bin/cc-test-reporter
-
- # add postgres signing key
-RUN curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
 
 ARG PG_VERSIONS
 ENV PG_VERSIONS=$PG_VERSIONS
@@ -50,25 +51,38 @@ ENV PG_VERSIONS=$PG_VERSIONS
 # because docker uses /bin/sh to execute the RUN commands where
 # the below code requires /bin/bash.
 SHELL ["/bin/bash", "-c"]
-RUN echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /etc/apt/sources.list.d/postgresql.list \
- && echo "deb https://apt-archive.postgresql.org/pub/repos/apt bullseye-pgdg-archive main" >> /etc/apt/sources.list.d/postgresql.list \
- && apt-get update \
- && pkgs=(); \
-    for PG_VERSION in $PG_VERSIONS; do \
-        PG_MAJOR=$(echo ${PG_VERSION} | awk -F'[^0-9]*' '/[0-9]/ { print $1 }'); \
-        pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 ); \
-        pkgs+=("postgresql-client-${PG_MAJOR}=${pgdg_version}"); \
-        pkgs+=("postgresql-${PG_MAJOR}-dbgsym=${pgdg_version}"); \
-        pkgs+=("postgresql-server-dev-${PG_MAJOR}=${pgdg_version}"); \
-        last_pgdg_version=$pgdg_version; \
-    done; \
-    pkgs+=("libpq-dev=${last_pgdg_version}"); \
-    pkgs+=("libpq5=${last_pgdg_version}"); \
-    echo ${pkgs[@]}\
- && apt-get install -y --no-install-recommends --allow-downgrades \
-    postgresql-common \
-    ${pkgs[@]} \
- && rm -rf /var/lib/apt/lists/*
+RUN <<'EOF'
+# install postgres ecosystem for pg versions: $PG_VERSIONS
+
+# install key and repositories
+curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -
+echo "deb https://apt.postgresql.org/pub/repos/apt bullseye-pgdg main" >> /etc/apt/sources.list.d/postgresql.list
+echo "deb https://apt-archive.postgresql.org/pub/repos/apt bullseye-pgdg-archive main" >> /etc/apt/sources.list.d/postgresql.list
+
+apt-get update
+
+pkgs=();
+for PG_VERSION in $PG_VERSIONS; do
+    PG_MAJOR=$(echo ${PG_VERSION} | awk -F'[^0-9]*' '/[0-9]/ { print $1 }')
+    pgdg_version=$(apt list -a postgresql-server-dev-${PG_MAJOR} 2>/dev/null | grep "${PG_VERSION}" | awk '{print $2}' | head -n1 )
+    pkgs+=("postgresql-client-${PG_MAJOR}=${pgdg_version}")
+    pkgs+=("postgresql-${PG_MAJOR}-dbgsym=${pgdg_version}")
+    pkgs+=("postgresql-server-dev-${PG_MAJOR}=${pgdg_version}")
+    last_pgdg_version=$pgdg_version;
+done;
+
+pkgs+=("libpq-dev=${last_pgdg_version}");
+pkgs+=("libpq5=${last_pgdg_version}");
+
+echo ${pkgs[@]}
+
+apt-get install -y --no-install-recommends --allow-downgrades \
+  postgresql-common \
+  ${pkgs[@]} \
+
+# clear apt cache
+rm -rf /var/lib/apt/lists/*
+EOF
 
 # setup /var/run/postgresql for use with circleci
 RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql

--- a/circleci/images/pgupgradetester/Dockerfile
+++ b/circleci/images/pgupgradetester/Dockerfile
@@ -6,6 +6,8 @@ RUN useradd -ms /bin/bash circleci
 
 RUN <<'EOF'
 # install dependencies
+set -eux
+
 apt-get update
 
 apt-get install -y --no-install-recommends \
@@ -53,6 +55,7 @@ ENV PG_VERSIONS=$PG_VERSIONS
 SHELL ["/bin/bash", "-c"]
 RUN <<'EOF'
 # install postgres ecosystem for pg versions: $PG_VERSIONS
+set -eux
 
 # install key and repositories
 curl -sf https://www.postgresql.org/media/keys/ACCC4CF8.asc | APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE=1 apt-key add -

--- a/circleci/images/stylechecker/Dockerfile
+++ b/circleci/images/stylechecker/Dockerfile
@@ -6,6 +6,8 @@ COPY ./files/etc/requirements.txt /tmp/etc/
 # openssh is needed in the image for CircleCI to pull the repo over ssh
 RUN <<'EOF'
 # install dependencies
+set -eux
+
 apk add --no-cache --virtual installdeps \
       curl \
       make \
@@ -32,7 +34,7 @@ curl -L "https://github.com/citusdata/tools/archive/v${TOOLS_VERSION}.tar.gz" | 
 cd "tools-${TOOLS_VERSION}"
 make uncrustify/.install
 cd ..
-rm -rf "citus-${VERSION}" "v${TOOLS_VERSION}.tar.gz"
+rm -rf "v${TOOLS_VERSION}.tar.gz"
 
 curl -L "https://github.com/uncrustify/uncrustify/archive/uncrustify-0.68.1.tar.gz" | tar xz
 cd uncrustify-uncrustify-0.68.1/

--- a/circleci/images/stylechecker/Dockerfile
+++ b/circleci/images/stylechecker/Dockerfile
@@ -4,7 +4,9 @@ ARG TOOLS_VERSION
 
 COPY ./files/etc/requirements.txt /tmp/etc/
 # openssh is needed in the image for CircleCI to pull the repo over ssh
-RUN apk add --no-cache --virtual installdeps \
+RUN <<'EOF'
+# install dependencies
+apk add --no-cache --virtual installdeps \
       curl \
       make \
       cmake \
@@ -15,7 +17,8 @@ RUN apk add --no-cache --virtual installdeps \
       py3-pip \
       python3-dev \
       tar \
-  && apk add --no-cache \
+
+apk add --no-cache \
       ca-certificates \
       bash \
       git \
@@ -24,20 +27,24 @@ RUN apk add --no-cache --virtual installdeps \
       perl \
       python3 \
       py3-packaging \
-  && curl -L "https://github.com/citusdata/tools/archive/v${TOOLS_VERSION}.tar.gz" | tar xz \
-  && cd "tools-${TOOLS_VERSION}" \
-  && make uncrustify/.install \
-  && cd .. \
-  && rm -rf "citus-${VERSION}" "v${TOOLS_VERSION}.tar.gz" \
-  && curl -L "https://github.com/uncrustify/uncrustify/archive/uncrustify-0.68.1.tar.gz" | tar xz \
-  && cd uncrustify-uncrustify-0.68.1/ \
-  && mkdir build \
-  && cd build \
-  && cmake .. \
-  && make -j5 \
-  && make install \
-  && cd ../.. \
-  && rm -rf uncrustify-uncrustify-0.68.1/ \
-  # this image is only used for testing purposes, so should be okay to overwrite system-managed packages
-  && pip3 install -Ir /tmp/etc/requirements.txt --break-system-packages \
-  && apk del installdeps
+
+curl -L "https://github.com/citusdata/tools/archive/v${TOOLS_VERSION}.tar.gz" | tar xz
+cd "tools-${TOOLS_VERSION}"
+make uncrustify/.install
+cd ..
+rm -rf "citus-${VERSION}" "v${TOOLS_VERSION}.tar.gz"
+
+curl -L "https://github.com/uncrustify/uncrustify/archive/uncrustify-0.68.1.tar.gz" | tar xz
+cd uncrustify-uncrustify-0.68.1/
+mkdir build
+cd build
+cmake ..
+make -j5
+make install
+cd ../..
+rm -rf uncrustify-uncrustify-0.68.1/
+
+# this image is only used for testing purposes, so should be okay to overwrite system-managed packages
+pip3 install -Ir /tmp/etc/requirements.txt --break-system-packages
+apk del installdeps
+EOF

--- a/circleci/images/stylechecker/files/etc/requirements.txt
+++ b/circleci/images/stylechecker/files/etc/requirements.txt
@@ -23,7 +23,7 @@ blinker==1.4
 brotli==1.0.9
 certifi==2024.2.2; python_version >= '3.6'
 cffi==1.16.0; platform_python_implementation != 'PyPy'
-construct==2.9.45
+construct==2.10.70; python_version >= '3.6'
 cryptography==42.0.3; python_version >= '3.7'
 docopt==0.6.2
 exceptiongroup==1.2.0; python_version < '3.11'


### PR DESCRIPTION
The main motivation of this patch is to move the images to the github container registry. But as quite often the case, the images were not building, thus some changes needed to be made to get the images to build.

 - Python construct package is bumped. There was a dependency failing to install, which succeeds on a newer version. This change is made by changing the version on the citus repo,  and re-export the requirements.txt
 - pin the `postgresql-$PG_MAJOR` version to the same pgdg version. For pg16.2 new packages have been created. This happens once in a while and to counter that we already pin most of the postgres ecosystem packages to a specific pgdg version. Somehow `postgresql-...` wasn't part of the pinning, causing some errors during image builds.

The scripts used the old syntax of multi line run blocks, requiring a lot of escaping and chaining of lines with the trailing `\` character. Newer versions of docker allow an easier to maintain and readable syntax via 
```Dockerfile
RUN <<'EOF'
# first comment will be shown during build as 'name' of the task
...
EOF
```

Given I already needed to change the body of many of the RUN blocks I took the liberty to refactor this at the same time. This is all captured in the first commit (barring I squash the fixups, let me know if I forgot :P). For review it might be easiest to review the commits separately.