### PR TITLE
Add CITUS_UPGRADE_VERSIONS_18 for PG18 exttester image

### DIFF
--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -22,6 +22,8 @@ CITUS_UPGRADE_PG_VERSIONS=$(shell head -n2 PG_VERSIONS|cut -c 6-|tr '\n' ' ')
 CITUS_UPGRADE_VERSIONS_16=v12.1.10
 # Latest minor version of Citus 13
 CITUS_UPGRADE_VERSIONS_17=v13.2.0
+# Latest minor version of Citus 14
+CITUS_UPGRADE_VERSIONS_18=v14.0.0
 
 # Function to get Citus versions for a specific PG major version
 get_citus_versions = $(CITUS_UPGRADE_VERSIONS_$(1))

--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -17,7 +17,7 @@ PG_UPGRADE_TESTER_VERSION=$(shell echo ${PG_VERSIONS}|tr ' ' '-'|sed 's/~//g')
 STYLE_CHECKER_TOOLS_VERSION=0.8.33
 
 # Upgrade tests for the PG major versions from PG_VERSIONS file 
-CITUS_UPGRADE_PG_VERSIONS=$(shell head -n2 PG_VERSIONS|cut -c 6-|tr '\n' ' ')
+CITUS_UPGRADE_PG_VERSIONS=$(shell head PG_VERSIONS|cut -c 6-|tr '\n' ' ')
 # 12.1.10 is the latest release of Citus 12 when the test is expanded to cover Citus 12
 CITUS_UPGRADE_VERSIONS_16=v12.1.10
 # Latest minor version of Citus 13


### PR DESCRIPTION
## Description

Add `CITUS_UPGRADE_VERSIONS_18=v14.0.0` to the Makefile so the exttester image for PG18 includes pre-built Citus 14.0 binaries.

## Check

```
$ docker run -it ghcr.io/citusdata/exttester:18.1-dev-181ce3c bash
root@2a07cb905f71:/home/circleci# ls /opt/citus-versions/
v14.0.0
root@2a07cb905f71:/home/circleci# ls /opt/citus-versions/v14.0.0/
citus.so  citus_columnar.so  citus_decoders  citus_pgoutput.so  citus_wal2json.so
```