### PR TITLE
Sync Citus image requirements to close pyOpenSSL CVE alerts

### DIFF
--- a/circleci/images/citusupgradetester/files/etc/requirements.txt
+++ b/circleci/images/citusupgradetester/files/etc/requirements.txt
@@ -1,4 +1,4 @@
-# generated from Citus's Pipfile.lock (in src/test/regress) as of citusdata/citus#8547
+# generated from Citus's Pipfile.lock (in src/test/regress) as of citusdata/citus#8596
 # using `pipenv requirements > requirements.txt`, so as to avoid the
 # need for pipenv/pyenv in this image
 
@@ -6,19 +6,19 @@
 aioquic==1.2.0; python_version >= '3.8'
 argon2-cffi==25.1.0; python_version >= '3.8'
 argon2-cffi-bindings==25.1.0; python_version >= '3.9'
-asgiref==3.11.0; python_version >= '3.9'
+asgiref==3.11.1; python_version >= '3.9'
 attrs==26.1.0; python_version >= '3.9'
 bcrypt==5.0.0; python_version >= '3.8'
 blinker==1.9.0; python_version >= '3.9'
 brotli==1.2.0
-certifi==2026.2.25; python_version >= '3.7'
+certifi==2026.5.20; python_version >= '3.7'
 cffi==2.0.0; python_version >= '3.9'
-click==8.3.2; python_version >= '3.10'
+click==8.4.1; python_version >= '3.10'
 construct==2.10.70; python_version >= '3.6'
 cryptography==46.0.7; python_version >= '3.8' and python_full_version not in '3.9.0, 3.9.1'
 docopt==0.6.2
 execnet==2.1.2; python_version >= '3.8'
-filelock==3.28.0; python_version >= '3.10'
+filelock==3.29.0; python_version >= '3.10'
 flask==3.1.3; python_version >= '3.9'
 h11==0.16.0; python_version >= '3.8'
 h2==4.3.0; python_version >= '3.9'
@@ -30,24 +30,24 @@ jinja2==3.1.6; python_version >= '3.7'
 kaitaistruct==0.11; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 ldap3==2.9.1
 markupsafe==3.0.3; python_version >= '3.9'
-mitmproxy @ git+https://github.com/citusdata/mitmproxy.git@70bad9a3c098f605e5f8b25553e5db5334018ff1
+mitmproxy @ git+https://github.com/citusdata/mitmproxy.git@df5879516a57ea780e1cc88edaf2051e1d32915f
 mitmproxy-linux==0.12.9; python_version >= '3.12'
 mitmproxy-rs==0.12.9; python_version >= '3.12'
 msgpack==1.1.2; python_version >= '3.9'
-packaging==26.1; python_version >= '3.8'
+packaging==26.2; python_version >= '3.8'
 pluggy==1.6.0; python_version >= '3.9'
-psycopg==3.3.3; python_version >= '3.10'
+psycopg==3.3.4; python_version >= '3.10'
 publicsuffix2==2.20191221
 pyasn1==0.6.3; python_version >= '3.8'
 pyasn1-modules==0.4.2; python_version >= '3.8'
 pycparser==3.0; python_version >= '3.10'
 pygments==2.20.0; python_version >= '3.9'
 pylsqpack==0.3.24; python_version >= '3.10'
-pyopenssl==25.3.0; python_version >= '3.7'
+pyopenssl==26.2.0; python_version >= '3.8'
 pyparsing==3.3.2; python_version >= '3.9'
 pyperclip==1.9.0
 pytest==9.0.3; python_version >= '3.10'
-pytest-asyncio==1.3.0; python_version >= '3.10'
+pytest-asyncio==1.4.0; python_version >= '3.10'
 pytest-repeat==0.9.4; python_version >= '3.9'
 pytest-timeout==2.4.0; python_version >= '3.7'
 pytest-xdist==3.8.0; python_version >= '3.9'
@@ -57,8 +57,8 @@ service-identity==24.2.0; python_version >= '3.8'
 sortedcontainers==2.4.0
 tornado==6.5.5; python_version >= '3.9'
 typing-extensions==4.14.0; python_version >= '3.9'
-urwid==3.0.5; python_full_version >= '3.9.0'
-wcwidth==0.6.0; python_version >= '3.8'
+urwid==4.0.0; python_full_version >= '3.9.0'
+wcwidth==0.7.0; python_version >= '3.8'
 werkzeug==3.1.6; python_version >= '3.9'
 wsproto==1.3.2; python_version >= '3.10'
 zstandard==0.25.0; python_version >= '3.9'

--- a/circleci/images/failtester/files/etc/requirements.txt
+++ b/circleci/images/failtester/files/etc/requirements.txt
@@ -1,4 +1,4 @@
-# generated from Citus's Pipfile.lock (in src/test/regress) as of citusdata/citus#8547
+# generated from Citus's Pipfile.lock (in src/test/regress) as of citusdata/citus#8596
 # using `pipenv requirements > requirements.txt`, so as to avoid the
 # need for pipenv/pyenv in this image
 
@@ -6,19 +6,19 @@
 aioquic==1.2.0; python_version >= '3.8'
 argon2-cffi==25.1.0; python_version >= '3.8'
 argon2-cffi-bindings==25.1.0; python_version >= '3.9'
-asgiref==3.11.0; python_version >= '3.9'
+asgiref==3.11.1; python_version >= '3.9'
 attrs==26.1.0; python_version >= '3.9'
 bcrypt==5.0.0; python_version >= '3.8'
 blinker==1.9.0; python_version >= '3.9'
 brotli==1.2.0
-certifi==2026.2.25; python_version >= '3.7'
+certifi==2026.5.20; python_version >= '3.7'
 cffi==2.0.0; python_version >= '3.9'
-click==8.3.2; python_version >= '3.10'
+click==8.4.1; python_version >= '3.10'
 construct==2.10.70; python_version >= '3.6'
 cryptography==46.0.7; python_version >= '3.8' and python_full_version not in '3.9.0, 3.9.1'
 docopt==0.6.2
 execnet==2.1.2; python_version >= '3.8'
-filelock==3.28.0; python_version >= '3.10'
+filelock==3.29.0; python_version >= '3.10'
 flask==3.1.3; python_version >= '3.9'
 h11==0.16.0; python_version >= '3.8'
 h2==4.3.0; python_version >= '3.9'
@@ -30,24 +30,24 @@ jinja2==3.1.6; python_version >= '3.7'
 kaitaistruct==0.11; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 ldap3==2.9.1
 markupsafe==3.0.3; python_version >= '3.9'
-mitmproxy @ git+https://github.com/citusdata/mitmproxy.git@70bad9a3c098f605e5f8b25553e5db5334018ff1
+mitmproxy @ git+https://github.com/citusdata/mitmproxy.git@df5879516a57ea780e1cc88edaf2051e1d32915f
 mitmproxy-linux==0.12.9; python_version >= '3.12'
 mitmproxy-rs==0.12.9; python_version >= '3.12'
 msgpack==1.1.2; python_version >= '3.9'
-packaging==26.1; python_version >= '3.8'
+packaging==26.2; python_version >= '3.8'
 pluggy==1.6.0; python_version >= '3.9'
-psycopg==3.3.3; python_version >= '3.10'
+psycopg==3.3.4; python_version >= '3.10'
 publicsuffix2==2.20191221
 pyasn1==0.6.3; python_version >= '3.8'
 pyasn1-modules==0.4.2; python_version >= '3.8'
 pycparser==3.0; python_version >= '3.10'
 pygments==2.20.0; python_version >= '3.9'
 pylsqpack==0.3.24; python_version >= '3.10'
-pyopenssl==25.3.0; python_version >= '3.7'
+pyopenssl==26.2.0; python_version >= '3.8'
 pyparsing==3.3.2; python_version >= '3.9'
 pyperclip==1.9.0
 pytest==9.0.3; python_version >= '3.10'
-pytest-asyncio==1.3.0; python_version >= '3.10'
+pytest-asyncio==1.4.0; python_version >= '3.10'
 pytest-repeat==0.9.4; python_version >= '3.9'
 pytest-timeout==2.4.0; python_version >= '3.7'
 pytest-xdist==3.8.0; python_version >= '3.9'
@@ -57,8 +57,8 @@ service-identity==24.2.0; python_version >= '3.8'
 sortedcontainers==2.4.0
 tornado==6.5.5; python_version >= '3.9'
 typing-extensions==4.14.0; python_version >= '3.9'
-urwid==3.0.5; python_full_version >= '3.9.0'
-wcwidth==0.6.0; python_version >= '3.8'
+urwid==4.0.0; python_full_version >= '3.9.0'
+wcwidth==0.7.0; python_version >= '3.8'
 werkzeug==3.1.6; python_version >= '3.9'
 wsproto==1.3.2; python_version >= '3.10'
 zstandard==0.25.0; python_version >= '3.9'

--- a/circleci/images/pgupgradetester/files/etc/requirements.txt
+++ b/circleci/images/pgupgradetester/files/etc/requirements.txt
@@ -1,4 +1,4 @@
-# generated from Citus's Pipfile.lock (in src/test/regress) as of citusdata/citus#8547
+# generated from Citus's Pipfile.lock (in src/test/regress) as of citusdata/citus#8596
 # using `pipenv requirements > requirements.txt`, so as to avoid the
 # need for pipenv/pyenv in this image
 
@@ -6,19 +6,19 @@
 aioquic==1.2.0; python_version >= '3.8'
 argon2-cffi==25.1.0; python_version >= '3.8'
 argon2-cffi-bindings==25.1.0; python_version >= '3.9'
-asgiref==3.11.0; python_version >= '3.9'
+asgiref==3.11.1; python_version >= '3.9'
 attrs==26.1.0; python_version >= '3.9'
 bcrypt==5.0.0; python_version >= '3.8'
 blinker==1.9.0; python_version >= '3.9'
 brotli==1.2.0
-certifi==2026.2.25; python_version >= '3.7'
+certifi==2026.5.20; python_version >= '3.7'
 cffi==2.0.0; python_version >= '3.9'
-click==8.3.2; python_version >= '3.10'
+click==8.4.1; python_version >= '3.10'
 construct==2.10.70; python_version >= '3.6'
 cryptography==46.0.7; python_version >= '3.8' and python_full_version not in '3.9.0, 3.9.1'
 docopt==0.6.2
 execnet==2.1.2; python_version >= '3.8'
-filelock==3.28.0; python_version >= '3.10'
+filelock==3.29.0; python_version >= '3.10'
 flask==3.1.3; python_version >= '3.9'
 h11==0.16.0; python_version >= '3.8'
 h2==4.3.0; python_version >= '3.9'
@@ -30,24 +30,24 @@ jinja2==3.1.6; python_version >= '3.7'
 kaitaistruct==0.11; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 ldap3==2.9.1
 markupsafe==3.0.3; python_version >= '3.9'
-mitmproxy @ git+https://github.com/citusdata/mitmproxy.git@70bad9a3c098f605e5f8b25553e5db5334018ff1
+mitmproxy @ git+https://github.com/citusdata/mitmproxy.git@df5879516a57ea780e1cc88edaf2051e1d32915f
 mitmproxy-linux==0.12.9; python_version >= '3.12'
 mitmproxy-rs==0.12.9; python_version >= '3.12'
 msgpack==1.1.2; python_version >= '3.9'
-packaging==26.1; python_version >= '3.8'
+packaging==26.2; python_version >= '3.8'
 pluggy==1.6.0; python_version >= '3.9'
-psycopg==3.3.3; python_version >= '3.10'
+psycopg==3.3.4; python_version >= '3.10'
 publicsuffix2==2.20191221
 pyasn1==0.6.3; python_version >= '3.8'
 pyasn1-modules==0.4.2; python_version >= '3.8'
 pycparser==3.0; python_version >= '3.10'
 pygments==2.20.0; python_version >= '3.9'
 pylsqpack==0.3.24; python_version >= '3.10'
-pyopenssl==25.3.0; python_version >= '3.7'
+pyopenssl==26.2.0; python_version >= '3.8'
 pyparsing==3.3.2; python_version >= '3.9'
 pyperclip==1.9.0
 pytest==9.0.3; python_version >= '3.10'
-pytest-asyncio==1.3.0; python_version >= '3.10'
+pytest-asyncio==1.4.0; python_version >= '3.10'
 pytest-repeat==0.9.4; python_version >= '3.9'
 pytest-timeout==2.4.0; python_version >= '3.7'
 pytest-xdist==3.8.0; python_version >= '3.9'
@@ -57,8 +57,8 @@ service-identity==24.2.0; python_version >= '3.8'
 sortedcontainers==2.4.0
 tornado==6.5.5; python_version >= '3.9'
 typing-extensions==4.14.0; python_version >= '3.9'
-urwid==3.0.5; python_full_version >= '3.9.0'
-wcwidth==0.6.0; python_version >= '3.8'
+urwid==4.0.0; python_full_version >= '3.9.0'
+wcwidth==0.7.0; python_version >= '3.8'
 werkzeug==3.1.6; python_version >= '3.9'
 wsproto==1.3.2; python_version >= '3.10'
 zstandard==0.25.0; python_version >= '3.9'

--- a/circleci/images/stylechecker/files/etc/requirements.txt
+++ b/circleci/images/stylechecker/files/etc/requirements.txt
@@ -1,19 +1,19 @@
-# generated from Citus's Pipfile.lock (in src/test/regress) as of citusdata/citus#8547
+# generated from Citus's Pipfile.lock (in src/test/regress) as of citusdata/citus#8596
 # using `pipenv requirements --dev-only > requirements.txt`, so as to avoid the
 # need for pipenv/pyenv in this image
 
 -i https://pypi.python.org/simple
 attrs==26.1.0; python_version >= '3.9'
 black==26.3.1; python_version >= '3.10'
-click==8.3.2; python_version >= '3.10'
+click==8.4.1; python_version >= '3.10'
 flake8==7.3.0; python_version >= '3.9'
 flake8-bugbear==25.11.29; python_version >= '3.10'
 isort==8.0.1; python_full_version >= '3.10.0'
 mccabe==0.7.0; python_version >= '3.6'
 mypy-extensions==1.1.0; python_version >= '3.8'
-packaging==26.1; python_version >= '3.8'
-pathspec==1.0.4; python_version >= '3.9'
-platformdirs==4.9.6; python_version >= '3.10'
+packaging==26.2; python_version >= '3.8'
+pathspec==1.1.1; python_version >= '3.9'
+platformdirs==4.10.0; python_version >= '3.10'
 pycodestyle==2.14.0; python_version >= '3.9'
 pyflakes==3.4.0; python_version >= '3.9'
 pytokens==0.4.1; python_version >= '3.8'


### PR DESCRIPTION
## Summary

Regenerates the four Citus image requirement files from the updated
Citus `Pipfile.lock` produced by [citusdata/citus#8596](https://github.com/citusdata/citus/pull/8596),
which lifts the [citusdata/mitmproxy](https://github.com/citusdata/mitmproxy)
fork's `pyOpenSSL` cap and pulls `pyOpenSSL` forward past two CVEs.

Pairs with:
- citusdata/citus#8596 — Pipfile/lock change (pyopenssl 25.3.0 → 26.2.0)
- citusdata/mitmproxy#4 — fork merge that lifted the cap (already merged)

## What changed

Three tester images, regenerated via `pipenv requirements > requirements.txt`
(byte-identical across `pgupgradetester`, `failtester`, `citusupgradetester`):

| package | before | after |
| --- | --- | --- |
| `pyopenssl` | 25.3.0 | **26.2.0** |
| `mitmproxy` (fork ref) | `70bad9a3` | **`df5879516`** |
| `asgiref` | 3.11.0 | 3.11.1 |
| `certifi` | 2026.2.25 | 2026.5.20 |
| `click` | 8.3.2 | 8.4.1 |
| `filelock` | 3.28.0 | 3.29.0 |
| `packaging` | 26.1 | 26.2 |
| `psycopg` | 3.3.3 | 3.3.4 |
| `pytest-asyncio` | 1.3.0 | 1.4.0 |
| `urwid` | 3.0.5 | 4.0.0 |
| `wcwidth` | 0.6.0 | 0.7.0 |

Stylechecker image, regenerated via `pipenv requirements --dev-only > requirements.txt`
(natural transitive drift from re-locking; no top-level dev deps changed):

| package | before | after |
| --- | --- | --- |
| `click` | 8.3.2 | 8.4.1 |
| `packaging` | 26.1 | 26.2 |
| `pathspec` | 1.0.4 | 1.1.1 |
| `platformdirs` | 4.9.6 | 4.10.0 |

No new top-level packages added or removed; no dropped pins.

## Notes

Same workflow as #214: regenerated artifacts following the instructions
in the file headers rather than hand-edited. Header PR reference bumped
`#8547` → `#8596` to track the source lockfile.

## Verification

- Installed both regenerated requirement sets in clean Python 3.12 venvs
  with `pip install -r ...`; both completed without resolver errors.
- `pip check` reports **no broken requirements** for both sets.
- Verified the installed `pyOpenSSL` version is `26.2.0` (closes CVE-2026-27459
  HIGH and CVE-2026-27448) and the installed `mitmproxy` resolves to the
  post-merge fork ref `df5879516`.
