### PR TITLE
Use Citus 13.3.0 for N-1 tests

### DIFF
--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -23,7 +23,7 @@ CITUS_UPGRADE_VERSIONS_15=v12.1.11
 # 12.1.10 is the latest release of Citus 12 when the test is expanded to cover Citus 12
 CITUS_UPGRADE_VERSIONS_16=v12.1.11
 # Latest minor version of Citus 13
-CITUS_UPGRADE_VERSIONS_17=v13.2.2
+CITUS_UPGRADE_VERSIONS_17=v13.3.0
 
 # Function to get Citus versions for a specific PG major version
 get_citus_versions = $(CITUS_UPGRADE_VERSIONS_$(1))


### PR DESCRIPTION
Bumps the N-1 (previous-version) Citus baked into the exttester image from `v13.2.2` to `v13.3.0` for PG17 (the N-1 slot on the release-13 / 13.x line).

## What
`circleci/images/Makefile`: `CITUS_UPGRADE_VERSIONS_17=v13.2.2` -> `v13.3.0`.

This makes exttester ship `/opt/citus-versions/v13.3.0`, which citusdata/citus N-1 CI will reference once the upcoming dev version moves to 13.4 and N-1 moves 13.2.2 -> 13.3.0.

## Why
Mirrors the prior blueprint (PR #214 `v13.2.0` -> `v13.2.2`). `v13.3.0` is the only 13.3 patch tag. Old version dropped wholesale, matching the blueprint.

## Coordination
Counterpart to the citusdata/citus 13.4-dev / N-1 13.3.0 change. Phase 1: this push mints `-dev-<sha>` images so citus CI can be validated green before merge mints the stable `-v<sha>` suffix.

Do NOT merge yet — pending citus N-1 13.3.0 CI validation.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>