### PR TITLE
Use Citus 14.1.0 for N-1 tests (release-14)

### DIFF
--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -23,7 +23,7 @@ CITUS_UPGRADE_VERSIONS_16=v12.1.12
 # Latest minor version of Citus 13
 CITUS_UPGRADE_VERSIONS_17=v13.2.2
 # Latest minor version of Citus 14
-CITUS_UPGRADE_VERSIONS_18=v14.0.1
+CITUS_UPGRADE_VERSIONS_18=v14.1.0
 
 # Function to get Citus versions for a specific PG major version
 get_citus_versions = $(CITUS_UPGRADE_VERSIONS_$(1))


### PR DESCRIPTION
Bumps the PG18 N-1 baked Citus version from `v14.0.1` to `v14.1.0` in `circleci/images/Makefile` (`CITUS_UPGRADE_VERSIONS_18`).

This is the 14.x counterpart to the release-13 13.3.0 change (PR #227), itself mirroring the prior 13.2.2 blueprint (PR #214). `v14.1.0` is the latest (and only) 14.1 patch; the exttester build bakes `get_last_citus_version,18` into `/opt/citus-versions/v14.1.0`, which the citus release-14 N-1 jobs consume.

Phase 1: push mints `-dev-<sha>` images on ghcr to validate citus N-1 14.1.0 CI before merging for the stable `-v<merge-sha>` suffix.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>