### PR TITLE
Produce stable image suffix on release-14 merges (symmetric with release-13)

### DIFF
--- a/.github/workflows/build-test-images.yml
+++ b/.github/workflows/build-test-images.yml
@@ -20,7 +20,7 @@ jobs:
       pgversions: ${{ toJSON(steps.get_versions.outputs.*) }}
 
   build_dev_images_per_postgres:
-    if: github.ref_name != 'master'
+    if: github.ref_name != 'master' && !startsWith(github.ref_name, 'release-')
     name: push-test-images-for-dev
     runs-on: ubuntu-latest
     permissions:
@@ -57,7 +57,7 @@ jobs:
           fi
 
   build_dev_images_shared:
-    if: github.ref_name != 'master'
+    if: github.ref_name != 'master' && !startsWith(github.ref_name, 'release-')
     name: push-test-images-for-dev
     runs-on: ubuntu-latest
     permissions:
@@ -92,7 +92,7 @@ jobs:
 
 
   build_release_images:
-    if: github.ref_name == 'master'
+    if: github.ref_name == 'master' || startsWith(github.ref_name, 'release-')
     needs: prepare_pgversion_matrix
     name: push-test-images-for-release
     runs-on: ubuntu-latest
@@ -109,7 +109,7 @@ jobs:
     steps: *build_images_per_pg_steps
 
   build_release_images_shared:
-    if: github.ref_name == 'master'
+    if: github.ref_name == 'master' || startsWith(github.ref_name, 'release-')
     name: push-shared-images-for-release
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Make the `release-14` `build-test-images` workflow symmetric with `release-13`.

**Problem:** On `release-13` the release image jobs fire for any `release-*` branch, so merging into `release-13` mints a stable `-v<sha>` suffix. On `release-14` the jobs are gated to `master` only, so merging into `release-14` produced only `-dev-<sha>` images (no stable `-v` suffix) — e.g. #228 merged and yielded only `-dev-877ec08`.

**Fix (surgical, 4 lines):** widen the branch guards so `release-*` merges route to the release jobs while feature/PR branches keep producing `-dev` images:

- `build_dev_images_per_postgres` / `build_dev_images_shared`: `!= 'master'` → `!= 'master' && !startsWith(github.ref_name, 'release-')`
- `build_release_images` / `build_release_images_shared`: `== 'master'` → `== 'master' || startsWith(github.ref_name, 'release-')`

The two guards remain mutually exclusive, so no job double-fires. Behaviorally symmetric to `release-13`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>