### PR TITLE
Use Citus 14.2.0 for N-1 tests (release-14)

### DIFF
--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -23,7 +23,7 @@ CITUS_UPGRADE_VERSIONS_16=v12.1.12
 # Latest minor version of Citus 13
 CITUS_UPGRADE_VERSIONS_17=v13.2.2
 # Latest minor version of Citus 14
-CITUS_UPGRADE_VERSIONS_18=v14.1.0
+CITUS_UPGRADE_VERSIONS_18=v14.2.0
 
 # Function to get Citus versions for a specific PG major version
 get_citus_versions = $(CITUS_UPGRADE_VERSIONS_$(1))


### PR DESCRIPTION
Bumps the PG18 / Citus 14.x baked version from `v14.1.0` to `v14.2.0` in `circleci/images/Makefile` (`CITUS_UPGRADE_VERSIONS_18`).

This follows the release-14 v14.1.0 N-1 image bump in PR #228. The published, non-prerelease Citus v14.2.0 tag is used by both the PG18 exttester and citusupgradetester Make expansions. PostgreSQL versions remain at the authoritative current minors: 16.14, 17.10, and 18.4.

The PR branch publishes `-dev-<sha>` images. After merge into `release-14`, the release workflow publishes stable images with suffix `-v<7-character merge SHA>`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>