### PR TITLE
Use Citus 13.4.0 for N-1 tests

### DIFF
--- a/circleci/images/Makefile
+++ b/circleci/images/Makefile
@@ -23,7 +23,7 @@ CITUS_UPGRADE_VERSIONS_15=v12.1.11
 # 12.1.10 is the latest release of Citus 12 when the test is expanded to cover Citus 12
 CITUS_UPGRADE_VERSIONS_16=v12.1.11
 # Latest minor version of Citus 13
-CITUS_UPGRADE_VERSIONS_17=v13.3.0
+CITUS_UPGRADE_VERSIONS_17=v13.4.0
 
 # Function to get Citus versions for a specific PG major version
 get_citus_versions = $(CITUS_UPGRADE_VERSIONS_$(1))


### PR DESCRIPTION
Bumps the N-1 (previous-version) Citus baked into the exttester image from `v13.3.0` to `v13.4.0` for PG17 (the N-1 slot on the release-13 / 13.x line).

## What
`circleci/images/Makefile`: `CITUS_UPGRADE_VERSIONS_17=v13.3.0` -> `v13.4.0`.

This makes exttester ship `/opt/citus-versions/v13.4.0` for citusdata/citus N-1 CI. The existing supported PostgreSQL minors remain unchanged at 15.18, 16.14, and 17.10.

## Why
Mirrors PR #227, which bumped the same PG17 slot from v13.2.2 to v13.3.0. The v13.4.0 tag is published in citusdata/citus, and the old version is replaced wholesale to match the established release-13 pattern.

## Validation
Validated Makefile target generation and dry-run expansion without Docker. The PG17 exttester build resolves `CITUS_VERSION="v13.4.0"`, and all expected PostgreSQL targets are generated.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>